### PR TITLE
Fix regex for the devices-long command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adb_client"
-version = "0.1.5"
+version = "0.1.6"
 description = "Rust ADB (Android Debug Bridge) client library"
 keywords = ["adb", "android"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -14,12 +14,18 @@ adb_client = "*"
 
 To launch a command on host device :
 ```rust
+use adb_client::AdbTcpConnexion;
+use adb_client::AdbCommandProvider;
+
 let connexion = AdbTcpConnexion::new();
 connexion.shell_command("df -h");
 ```
 
 To get available ADB devices :
 ```rust
+use adb_client::AdbTcpConnexion;
+use adb_client::AdbCommandProvider;
+
 let connexion = AdbTcpConnexion::new();
 connexion.devices();
 ```
@@ -28,7 +34,7 @@ connexion.devices();
 ## Rust binary
 
 You can install the lightweight adb binary by running the following command :
-```
+```shell
 cargo install adb_client --features adbclient 
 ```
 

--- a/bin/adb_client.rs
+++ b/bin/adb_client.rs
@@ -30,7 +30,7 @@ enum Command {
     /// Tracks new devices showing up
     TrackDevices,
     /// Run 'command' in a shell on the device, and return its output and error streams.
-    Shell { command: Vec<String> },
+    Shell { command: Option<String> },
 }
 
 fn main() -> Result<()> {
@@ -69,10 +69,10 @@ fn main() -> Result<()> {
             connexion.track_devices(callback)?;
         }
         Command::Shell { command } => {
-            if command.is_empty() {
-                connexion.shell()?;
-            } else {
+            if let Some(command) = command {
                 connexion.shell_command(command)?;
+            } else {
+                connexion.shell()?;
             }
         }
     }

--- a/src/models/device_long.rs
+++ b/src/models/device_long.rs
@@ -44,14 +44,11 @@ impl TryFrom<Vec<u8>> for DeviceLong {
 
     // TODO: Prevent regex compilation every call to try_from()
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        let parse_regex = Regex::new(
-            "^(?P<identifier>\\w+)\\s+(?P<state>\\w+) usb:(?P<usb>.*) (product:(?P<product>\\w+) model:(?P<model>\\w+) device:(?P<device>\\w+))?transport_id:(?P<transport_id>\\d+)$",
-    ).expect("failed to create regex");
+        let parse_regex = Regex::new("^(?P<identifier>\\w+)\\s+(?P<state>\\w+) usb:(?P<usb>.*) (product:(?P<product>\\w+) model:(?P<model>\\w+) device:(?P<device>\\w+) )?transport_id:(?P<transport_id>\\d+)$")?;
 
-        let groups = parse_regex.captures(&value).expect(&format!(
-            "failed to parse regex, value is: {}",
-            std::str::from_utf8(&value).unwrap()
-        ));
+        let groups = parse_regex
+            .captures(&value)
+            .ok_or(RustADBError::RegexParsingError)?;
 
         Ok(DeviceLong {
             identifier: String::from_utf8(

--- a/src/models/device_long.rs
+++ b/src/models/device_long.rs
@@ -45,6 +45,7 @@ impl TryFrom<Vec<u8>> for DeviceLong {
     // TODO: Prevent regex compilation every call to try_from()
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         let parse_regex = Regex::new("^(\\w+)       (\\w+) usb:(.*) product:(\\w+) model:(\\w+) device:(\\w+) transport_id:(\\d+)$")?;
+        let parse_regex = Regex::new("^(\\w+)\\s+(\\w+) usb:(.*) product:(\\w+) model:(\\w+) device:(\\w+) transport_id:(\\d+)$")?;
 
         let groups = parse_regex.captures(&value).unwrap();
         Ok(DeviceLong {

--- a/src/traits/adb_command_provider.rs
+++ b/src/traits/adb_command_provider.rs
@@ -18,7 +18,7 @@ pub trait AdbCommandProvider {
     /// Asks ADB server to switch the connection to either the device or emulator connect to/running on the host. Will fail if there is more than one such device/emulator available.
     fn transport_any(&self) -> Result<()>;
     /// Runs 'command' in a shell on the device, and return its output and error streams.
-    fn shell_command(&self, command: Vec<String>) -> Result<()>;
+    fn shell_command<S: ToString>(&self, command: S) -> Result<()>;
     /// Starts an interactive shell session on the device. Redirects stdin/stdout/stderr as appropriate.
     fn shell(&self) -> Result<()>;
 }


### PR DESCRIPTION
    In some setups the exact number of spaces didn't match, so made it more  generic using the 'whitespace class' (\s)

    When an adb device is offline, the `devices-l` command output does not contain product, model, or device attributes (besides the state being `offline` of course).
    e.g.
    <IDENTIFIER>            offline usb:1-10 transport_id:14911
    <IDENTIFIER>            device usb:1-9 product:<product> model:<MODEL> device:<device> transport_id:14703
    
    In order to support both formats, the regex has changed to use named groups, with the group of all these three being optional. When creating the DeviceLong struct, if these fields are unknown they are set to "Unk".
