### PR TITLE
`shell_command` takes `IntoIterator` instead of `Vec`.

### DIFF
--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -8,7 +8,11 @@ use crate::{
 
 impl AdbTcpConnexion {
     /// Runs 'command' in a shell on the device, and return its output and error streams.
-    pub fn shell_command<S: ToString>(&mut self, serial: Option<S>, command: Vec<S>) -> Result<()> {
+    pub fn shell_command<S: ToString>(
+        &mut self,
+        serial: Option<S>,
+        command: impl IntoIterator<Item = S>,
+    ) -> Result<()> {
         let supported_features = self.host_features()?;
         if !supported_features.contains(&HostFeatures::ShellV2)
             && !supported_features.contains(&HostFeatures::Cmd)
@@ -29,9 +33,9 @@ impl AdbTcpConnexion {
             &mut self.tcp_stream,
             AdbCommand::ShellCommand(
                 command
-                    .iter()
+                    .into_iter()
                     .map(|v| v.to_string())
-                    .collect::<Vec<String>>()
+                    .collect::<Vec<_>>()
                     .join(" "),
             ),
         )?;


### PR DESCRIPTION
Currently the `command` parameter of `shell_command` has a type of `Vec`. That is normally OK, but it is kinda tedious to manually collect an iterator ( `iter.map(...).collect::<Vec<_>>()` ) when instead you could just pass `iter.map(...)` directly.

This also will let the user pass an array as parameter ( because arrays implement `IntoIterator` too. )