### PR TITLE
Allow host-feature to accept serial number of adb connection

### DIFF
--- a/examples/adb_cli.rs
+++ b/examples/adb_cli.rs
@@ -108,7 +108,7 @@ fn main() -> Result<(), RustADBError> {
         }
         Command::HostFeatures => {
             println!("Available host features");
-            for feature in connexion.host_features()? {
+            for feature in connexion.host_features(opt.serial)? {
                 println!("- {}", feature);
             }
         }

--- a/examples/adb_cli.rs
+++ b/examples/adb_cli.rs
@@ -101,20 +101,20 @@ fn main() -> Result<(), RustADBError> {
         }
         Command::Shell { command } => {
             if command.is_empty() {
-                connexion.shell(opt.serial)?;
+                connexion.shell(&opt.serial)?;
             } else {
-                connexion.shell_command(opt.serial, command)?;
+                connexion.shell_command(&opt.serial, command)?;
             }
         }
         Command::HostFeatures => {
             println!("Available host features");
-            for feature in connexion.host_features(opt.serial)? {
+            for feature in connexion.host_features(&opt.serial)? {
                 println!("- {}", feature);
             }
         }
         Command::Reboot { sub_command } => {
             println!("Reboots device");
-            connexion.reboot(opt.serial, sub_command.into())?
+            connexion.reboot(&opt.serial, sub_command.into())?
         }
     }
 

--- a/src/commands/host_features.rs
+++ b/src/commands/host_features.rs
@@ -5,7 +5,18 @@ use crate::{
 
 impl AdbTcpConnexion {
     /// Lists available ADB server features.
-    pub fn host_features(&mut self) -> Result<Vec<HostFeatures>> {
+    pub fn host_features<S: ToString + Clone>(
+        &mut self,
+        serial: Option<S>,
+    ) -> Result<Vec<HostFeatures>> {
+        match serial {
+            None => Self::send_adb_request(&mut self.tcp_stream, AdbCommand::TransportAny)?,
+            Some(serial) => Self::send_adb_request(
+                &mut self.tcp_stream,
+                AdbCommand::TransportSerial(serial.to_string()),
+            )?,
+        }
+
         let features = self.proxy_connexion(AdbCommand::HostFeatures, true)?;
 
         Ok(features

--- a/src/commands/host_features.rs
+++ b/src/commands/host_features.rs
@@ -5,10 +5,7 @@ use crate::{
 
 impl AdbTcpConnexion {
     /// Lists available ADB server features.
-    pub fn host_features<S: ToString + Clone>(
-        &mut self,
-        serial: Option<S>,
-    ) -> Result<Vec<HostFeatures>> {
+    pub fn host_features<S: ToString>(&mut self, serial: &Option<S>) -> Result<Vec<HostFeatures>> {
         match serial {
             None => Self::send_adb_request(&mut self.tcp_stream, AdbCommand::TransportAny)?,
             Some(serial) => Self::send_adb_request(

--- a/src/commands/reboot.rs
+++ b/src/commands/reboot.rs
@@ -5,12 +5,17 @@ use crate::{
 
 impl AdbTcpConnexion {
     /// Reboots the device
-    pub fn reboot(&mut self, serial: Option<String>, reboot_type: RebootType) -> Result<()> {
+    pub fn reboot<S: ToString>(
+        &mut self,
+        serial: &Option<S>,
+        reboot_type: RebootType,
+    ) -> Result<()> {
         match serial {
             None => Self::send_adb_request(&mut self.tcp_stream, AdbCommand::TransportAny)?,
-            Some(serial) => {
-                Self::send_adb_request(&mut self.tcp_stream, AdbCommand::TransportSerial(serial))?
-            }
+            Some(serial) => Self::send_adb_request(
+                &mut self.tcp_stream,
+                AdbCommand::TransportSerial(serial.to_string()),
+            )?,
         }
 
         self.proxy_connexion(AdbCommand::Reboot(reboot_type), false)

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -8,12 +8,12 @@ use crate::{
 
 impl AdbTcpConnexion {
     /// Runs 'command' in a shell on the device, and return its output and error streams.
-    pub fn shell_command<S: ToString>(
+    pub fn shell_command<S: ToString + Clone>(
         &mut self,
         serial: Option<S>,
         command: impl IntoIterator<Item = S>,
     ) -> Result<()> {
-        let supported_features = self.host_features()?;
+        let supported_features = self.host_features(serial.clone())?;
         if !supported_features.contains(&HostFeatures::ShellV2)
             && !supported_features.contains(&HostFeatures::Cmd)
         {
@@ -60,7 +60,7 @@ impl AdbTcpConnexion {
     }
 
     /// Starts an interactive shell session on the device. Redirects stdin/stdout/stderr as appropriate.
-    pub fn shell<S: ToString>(&mut self, serial: Option<S>) -> Result<()> {
+    pub fn shell<S: ToString + Clone>(&mut self, serial: Option<S>) -> Result<()> {
         let mut adb_termios = ADBTermios::new(std::io::stdin())?;
         adb_termios.set_adb_termios()?;
 
@@ -68,7 +68,7 @@ impl AdbTcpConnexion {
 
         // FORWARD CRTL+C !!
 
-        let supported_features = self.host_features()?;
+        let supported_features = self.host_features(serial.clone())?;
         if !supported_features.contains(&HostFeatures::ShellV2)
             && !supported_features.contains(&HostFeatures::Cmd)
         {

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -8,12 +8,12 @@ use crate::{
 
 impl AdbTcpConnexion {
     /// Runs 'command' in a shell on the device, and return its output and error streams.
-    pub fn shell_command<S: ToString + Clone>(
+    pub fn shell_command<S: ToString>(
         &mut self,
-        serial: Option<S>,
+        serial: &Option<S>,
         command: impl IntoIterator<Item = S>,
     ) -> Result<()> {
-        let supported_features = self.host_features(serial.clone())?;
+        let supported_features = self.host_features(serial)?;
         if !supported_features.contains(&HostFeatures::ShellV2)
             && !supported_features.contains(&HostFeatures::Cmd)
         {
@@ -60,7 +60,7 @@ impl AdbTcpConnexion {
     }
 
     /// Starts an interactive shell session on the device. Redirects stdin/stdout/stderr as appropriate.
-    pub fn shell<S: ToString + Clone>(&mut self, serial: Option<S>) -> Result<()> {
+    pub fn shell<S: ToString>(&mut self, serial: &Option<S>) -> Result<()> {
         let mut adb_termios = ADBTermios::new(std::io::stdin())?;
         adb_termios.set_adb_termios()?;
 
@@ -68,7 +68,7 @@ impl AdbTcpConnexion {
 
         // FORWARD CRTL+C !!
 
-        let supported_features = self.host_features(serial.clone())?;
+        let supported_features = self.host_features(serial)?;
         if !supported_features.contains(&HostFeatures::ShellV2)
             && !supported_features.contains(&HostFeatures::Cmd)
         {


### PR DESCRIPTION
Instead of having serial being passed as reference, I clone it, thus had to add the 'Clone' trait to the serial type.

Passing it as a reference would make the API inconsistent.

Other suggestions are welcome, still learning...