### PR TITLE
Adb devices changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "adb_client"
 readme = "README.md"
 repository = "https://github.com/cocool97/adb_client"
-version = "0.5.0"
+version = "0.6.0"
 
 [lib]
 name = "adb_client"
@@ -17,11 +17,11 @@ name = "adb_cli"
 path = "examples/adb_cli.rs"
 
 [dependencies]
-regex = { version = "1.7.3", features = ["perf", "std", "unicode"] }
+regex = { version = "1.9.3", features = ["perf", "std", "unicode"] }
 termios = { version = "0.3.3" }
-thiserror = { version = "1.0.40" }
+thiserror = { version = "1.0.44" }
 
 ## Binary-only dependencies
 ## Marked as optional so that lib users do not depend on them
 [dev-dependencies]
-clap = { version = "= 4.2.1", features = ["derive"] }
+clap = { version = "= 4.3.21", features = ["derive"] }

--- a/src/commands/devices.rs
+++ b/src/commands/devices.rs
@@ -37,7 +37,7 @@ impl AdbTcpConnexion {
 
     /// Tracks new devices showing up.
     // TODO: Change with Generator when feature stabilizes
-    pub fn track_devices(&mut self, callback: fn(Device) -> Result<()>) -> Result<()> {
+    pub fn track_devices(&mut self, callback: impl Fn(Device) -> Result<()>) -> Result<()> {
         Self::send_adb_request(&mut self.tcp_stream, AdbCommand::TrackDevices)?;
 
         loop {

--- a/src/models/device_state.rs
+++ b/src/models/device_state.rs
@@ -11,6 +11,8 @@ pub enum DeviceState {
     Device,
     /// There is no device connected.
     NoDevice,
+    /// Device is being authorized
+    Authorizing,
     /// The device is unauthorized.
     Unauthorized,
 }
@@ -21,6 +23,7 @@ impl Display for DeviceState {
             DeviceState::Offline => write!(f, "offline"),
             DeviceState::Device => write!(f, "device"),
             DeviceState::NoDevice => write!(f, "no device"),
+            DeviceState::Authorizing => write!(f, "authorizing"),
             DeviceState::Unauthorized => write!(f, "unauthorized"),
         }
     }
@@ -35,6 +38,7 @@ impl FromStr for DeviceState {
             "offline" => Ok(Self::Offline),
             "device" => Ok(Self::Device),
             "no device" => Ok(Self::NoDevice),
+            "authorizing" => Ok(Self::Authorizing),
             "unauthorized" => Ok(Self::Unauthorized),
             _ => Err(RustADBError::UnknownDeviceState(lowercased)),
         }


### PR DESCRIPTION
- Changes `track_devices` prototype to take impl Fn (issue #12)
- Adds "authorizing" state for device
- Bump dependencies