### PR TITLE
Read length with get_body_length correctly

### DIFF
--- a/src/adb_tcp_connection.rs
+++ b/src/adb_tcp_connection.rs
@@ -5,6 +5,8 @@ use std::{
     str::FromStr,
 };
 
+use byteorder::{ByteOrder, LittleEndian};
+
 use crate::{
     models::{AdbCommand, AdbRequestStatus, SyncCommand},
     Result, RustADBError,
@@ -102,9 +104,8 @@ impl AdbTcpConnection {
     }
 
     pub(crate) fn get_body_length(&mut self) -> Result<u32> {
-        let mut length = [0; 4];
-        self.tcp_stream.read_exact(&mut length)?;
-
-        Ok(u32::from_str_radix(str::from_utf8(&length)?, 16)?)
+        let mut len_buf = [0; 4];
+        self.tcp_stream.read_exact(&mut len_buf)?;
+        Ok(LittleEndian::read_u32(&len_buf))
     }
 }

--- a/src/commands/devices.rs
+++ b/src/commands/devices.rs
@@ -41,7 +41,7 @@ impl AdbTcpConnection {
         self.send_adb_request(AdbCommand::TrackDevices)?;
 
         loop {
-            let length = self.get_body_length()?;
+            let length = self.get_body_length(true)?;
 
             if length > 0 {
                 let mut body = vec![

--- a/src/commands/recv.rs
+++ b/src/commands/recv.rs
@@ -52,14 +52,14 @@ impl AdbTcpConnection {
             match &data_header {
                 b"DATA" => {
                     // Handle received data
-                    let length: usize = self.get_body_length()?.try_into().unwrap();
+                    let length: usize = self.get_body_length(false)?.try_into().unwrap();
                     self.tcp_stream.read_exact(&mut buffer[..length])?;
                     output.write_all(&buffer)?;
                 }
                 b"DONE" => break, // We're done here
                 b"FAIL" => {
                     // Handle fail
-                    let length: usize = self.get_body_length()?.try_into().unwrap();
+                    let length: usize = self.get_body_length(false)?.try_into().unwrap();
                     self.tcp_stream.read_exact(&mut buffer[..length])?;
                     Err(RustADBError::ADBRequestFailed(String::from_utf8(
                         buffer[..length].to_vec(),

--- a/src/commands/recv.rs
+++ b/src/commands/recv.rs
@@ -46,28 +46,26 @@ impl AdbTcpConnection {
         // Chunk looks like 'DATA' <length> <data>
         let mut buffer = [0_u8; 64 * 1024]; // Should this be Boxed?
         let mut data_header = [0_u8; 4]; // DATA
-        let mut len_header = [0_u8; 4]; // <len>
         loop {
             self.tcp_stream.read_exact(&mut data_header)?;
-            // Check if data_header is DATA or DONE
-            if data_header.eq(b"DATA") {
-                self.tcp_stream.read_exact(&mut len_header)?;
-                let length: usize = LittleEndian::read_u32(&len_header).try_into().unwrap();
-                self.tcp_stream.read_exact(&mut buffer[..length])?;
-                output.write_all(&buffer)?;
-            } else if data_header.eq(b"DONE") {
-                // We're done here
-                break;
-            } else if data_header.eq(b"FAIL") {
-                // Handle fail
-                self.tcp_stream.read_exact(&mut len_header)?;
-                let length: usize = LittleEndian::read_u32(&len_header).try_into().unwrap();
-                self.tcp_stream.read_exact(&mut buffer[..length])?;
-                Err(RustADBError::ADBRequestFailed(String::from_utf8(
-                    buffer[..length].to_vec(),
-                )?))?;
-            } else {
-                panic!("Unknown response from device {:#?}", data_header);
+            // Check if data_header is DATA or DONE or FAIL
+            match &data_header {
+                b"DATA" => {
+                    // Handle received data
+                    let length: usize = self.get_body_length()?.try_into().unwrap();
+                    self.tcp_stream.read_exact(&mut buffer[..length])?;
+                    output.write_all(&buffer)?;
+                }
+                b"DONE" => break, // We're done here
+                b"FAIL" => {
+                    // Handle fail
+                    let length: usize = self.get_body_length()?.try_into().unwrap();
+                    self.tcp_stream.read_exact(&mut buffer[..length])?;
+                    Err(RustADBError::ADBRequestFailed(String::from_utf8(
+                        buffer[..length].to_vec(),
+                    )?))?;
+                }
+                _ => panic!("Unknown response from device {:#?}", data_header),
             }
         }
 

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -80,7 +80,7 @@ impl AdbTcpConnection {
         match AdbRequestStatus::from_str(str::from_utf8(request_status.as_ref())?)? {
             AdbRequestStatus::Fail => {
                 // We can keep reading to get further details
-                let length = self.get_body_length()?;
+                let length = self.get_body_length(false)?;
 
                 let mut body = vec![
                     0;


### PR DESCRIPTION
I was trying the send command when i got a weird error message: `Error: ParseIntError(ParseIntError { kind: InvalidDigit })`, by passing a directory as a path.
After debugging, i've discovered that the `handle_send_command` and `send_adb_request` methods didn't handle fail properly. Both were using `get_body_length` to read the 4 bytes len, but it was made to read them in hex, for `proxy_connection` and `track_devices`.
This should fix the issue.

NOTE: To make the code clearer, we could split `get_body_length` or maybe use a macro.