### PR TITLE
add windows support via cfg feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ image = { version = "0.25.1" }
 lazy_static = { version = "1.5.0" }
 mio = { version = "1.0.0", features = ["os-ext", "os-poll"] }
 regex = { version = "1.10.5", features = ["perf", "std", "unicode"] }
-termios = { version = "0.3.3" }
 thiserror = { version = "1.0.62" }
+termios = { version = "0.3.3", optional = true }
 
 ## Binary-only dependencies
 ## Marked as optional so that lib users do not depend on them
@@ -32,3 +32,11 @@ thiserror = { version = "1.0.62" }
 anyhow = { version = "1.0.86" }
 clap = { version = "4.5.9", features = ["derive"] }
 rand = { version = "0.8.5" }
+
+[target.'cfg(not(windows))'.features]
+# termios only supports POSIX platforms, so we exclude it from the windows target
+default = ["termios"]
+termios = ["termios"]
+[target.'cfg(windows)'.features]
+deafult = []
+termios = ["termios"]

--- a/examples/adb_cli.rs
+++ b/examples/adb_cli.rs
@@ -2,6 +2,7 @@ use adb_client::{ADBServer, DeviceShort, RebootType};
 use anyhow::Result;
 use clap::Parser;
 use std::fs::File;
+#[cfg(feature = "termios")]
 use std::io::{self, Write};
 use std::net::SocketAddrV4;
 use std::path::Path;
@@ -49,6 +50,7 @@ pub enum LocalCommand {
         path: String,
     },
     /// Spawn an interactive shell or run a list of commands on the device
+    #[cfg(feature = "termios")]
     Shell {
         command: Vec<String>,
     },
@@ -131,6 +133,7 @@ fn main() -> Result<()> {
                     let stat_response = device.stat(path)?;
                     println!("{}", stat_response);
                 }
+                #[cfg(feature = "termios")]
                 LocalCommand::Shell { command } => {
                     if command.is_empty() {
                         device.shell()?;

--- a/src/adb_termios.rs
+++ b/src/adb_termios.rs
@@ -1,8 +1,6 @@
-use std::os::unix::prelude::{AsRawFd, RawFd};
-
-use termios::{tcsetattr, Termios, TCSANOW, VMIN, VTIME};
-
 use crate::Result;
+use std::os::unix::prelude::{AsRawFd, RawFd};
+use termios::{tcsetattr, Termios, TCSANOW, VMIN, VTIME};
 
 pub struct ADBTermios {
     fd: RawFd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![forbid(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "termios")]
 mod adb_termios;
 mod error;
 mod models;

--- a/src/models/adb_command.rs
+++ b/src/models/adb_command.rs
@@ -16,6 +16,7 @@ pub(crate) enum AdbCommand {
     TransportAny,
     TransportSerial(String),
     ShellCommand(String),
+    #[cfg(feature = "termios")]
     Shell,
     FrameBuffer,
     Sync,
@@ -37,6 +38,7 @@ impl Display for AdbCommand {
                 Ok(term) => write!(f, "shell,TERM={term},raw:{command}"),
                 Err(_) => write!(f, "shell,raw:{command}"),
             },
+            #[cfg(feature = "termios")]
             AdbCommand::Shell => match std::env::var("TERM") {
                 Ok(term) => write!(f, "shell,TERM={term},raw:"),
                 Err(_) => write!(f, "shell,raw:"),


### PR DESCRIPTION
Gets this crate compiling on windows by disabling `termios` and interactive-shell related features in the windows build.

Closes #9

I want to call out that this needs to be tested to still compile on the original target platforms! I didn't see any CI tests and I'm not running linux as my daily driver at the moment to test myself 😅 