### PR TITLE
Add helper functions and protocol constants

### DIFF
--- a/adb_cli/src/commands/usb.rs
+++ b/adb_cli/src/commands/usb.rs
@@ -1,18 +1,20 @@
 use clap::Parser;
 
+fn hex_id_to_u16(id: &str) -> Result<u16, std::num::ParseIntError> {
+    u16::from_str_radix(id, 16)
+}
+
 #[derive(Parser, Debug)]
 pub struct UsbCommand {
     /// Vendor id of this USB device
-    #[clap(short = 'v', long = "vendor-id")]
+    #[clap(short = 'v', long = "vendor-id", value_parser = hex_id_to_u16)]
     pub vendor_id: u16,
     /// Product id of this USB device
-    #[clap(short = 'p', long = "product-id")]
+    #[clap(short = 'p', long = "product-id", value_parser = hex_id_to_u16)]
     pub product_id: u16,
     // #[clap(subcommand)]
     // pub commands: UsbCommands
 }
 
 #[derive(Parser, Debug)]
-pub enum UsbCommands {
-
-}
+pub enum UsbCommands {}

--- a/adb_client/src/usb/adb_usb_device.rs
+++ b/adb_client/src/usb/adb_usb_device.rs
@@ -1,5 +1,6 @@
-use crate::{ADBTransport, Result, USBTransport};
 use super::ADBUsbMessageHeader;
+use crate::usb::constants::{CMD_CNXN, CONNECT_MAXDATA, CONNECT_PAYLOAD, CONNECT_VERSION};
+use crate::{ADBTransport, Result, USBTransport};
 
 /// Represent a device reached directly over USB
 #[derive(Debug)]
@@ -19,10 +20,10 @@ impl ADBUSBDevice {
         self.transport.connect()?;
 
         let message = ADBUsbMessageHeader::new(
-            0x4e584e43,
-            0x01000000,
-            1048576,
-            "host::pc-portable\0".into(),
+            CMD_CNXN,
+            CONNECT_VERSION,
+            CONNECT_MAXDATA,
+            CONNECT_PAYLOAD.into(),
         );
 
         self.transport.write(message)?;

--- a/adb_client/src/usb/constants.rs
+++ b/adb_client/src/usb/constants.rs
@@ -1,0 +1,11 @@
+pub const CMD_CNXN: u32 = 0x4e584e43;
+pub const CMD_AUTH: u32 = 0x48545541;
+pub const CMD_OPEN: u32 = 0x4e45504f;
+pub const CMD_OKAY: u32 = 0x59414b4f;
+pub const CMD_WRTE: u32 = 0x45545257;
+pub const CMD_SYNC: u32 = 0x434e5953;
+pub const CMD_CLSE: u32 = 0x45534c43;
+
+pub const CONNECT_VERSION: u32 = 0x01000000;
+pub const CONNECT_MAXDATA: u32 = 4096;
+pub const CONNECT_PAYLOAD: &str = "host::\0";

--- a/adb_client/src/usb/mod.rs
+++ b/adb_client/src/usb/mod.rs
@@ -1,5 +1,6 @@
 mod adb_usb_device;
 mod adb_usb_message;
+mod constants;
 mod usb_commands;
 pub use adb_usb_device::ADBUSBDevice;
 pub use adb_usb_message::ADBUsbMessageHeader;


### PR DESCRIPTION
### Changes
- Added small temporary `value_parser` function for clap to parse hex VIDs and PIDs as available from `lsusb` command
- Created `constants.rs` module for constants to send over the USB protocol, like `CMD_CNXN`
- Set connection maxdata to 4096 (not sure if 1048576 is supported everywhere)