### PR TITLE
usb: Read RSA keypair from user home or generate them

### DIFF
--- a/adb_cli/src/commands/usb.rs
+++ b/adb_cli/src/commands/usb.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use std::num::ParseIntError;
+use std::path::PathBuf;
 
 use clap::Parser;
 
@@ -15,14 +15,10 @@ pub struct UsbCommand {
     /// Hexadecimal product id of this USB device
     #[clap(short = 'p', long = "product-id", value_parser=parse_hex_id, value_name="PID")]
     pub product_id: u16,
-    /// Path to a custom public key for authentication
-    #[clap(long = "public-key")]
-    pub public_key: Option<PathBuf>,
 
     /// Path to a custom private key for authentication
     #[clap(long = "private-key")]
     pub private_key: Option<PathBuf>,
-
     // #[clap(subcommand)]
     // pub commands: UsbCommands
 }

--- a/adb_cli/src/commands/usb.rs
+++ b/adb_cli/src/commands/usb.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -10,6 +12,13 @@ pub struct UsbCommand {
     pub product_id: u16,
     // #[clap(subcommand)]
     // pub commands: UsbCommands
+    /// Path to a custom public key for authentication
+    #[clap(long = "public-key")]
+    pub public_key: Option<PathBuf>,
+
+    /// Path to a custom private key for authentication
+    #[clap(long = "private-key")]
+    pub private_key: Option<PathBuf>,
 }
 
 #[derive(Parser, Debug)]

--- a/adb_cli/src/commands/usb.rs
+++ b/adb_cli/src/commands/usb.rs
@@ -15,10 +15,9 @@ pub struct UsbCommand {
     /// Hexadecimal product id of this USB device
     #[clap(short = 'p', long = "product-id", value_parser=parse_hex_id, value_name="PID")]
     pub product_id: u16,
-
-    /// Path to a custom private key for authentication
-    #[clap(long = "private-key")]
-    pub private_key: Option<PathBuf>,
+    /// Path to a custom private key to use for authentication
+    #[clap(short = 'k', long = "private-key")]
+    pub path_to_private_key: Option<PathBuf>,
     // #[clap(subcommand)]
     // pub commands: UsbCommands
 }

--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -153,12 +153,7 @@ fn main() -> Result<()> {
             }
         }
         Command::Usb(usb) => {
-            let mut device = ADBUSBDevice::new(
-                usb.vendor_id,
-                usb.product_id,
-                usb.private_key,
-                usb.public_key,
-            )?;
+            let mut device = ADBUSBDevice::new(usb.vendor_id, usb.product_id, usb.private_key)?;
             device.send_connect()?;
         }
     }

--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -153,7 +153,8 @@ fn main() -> Result<()> {
             }
         }
         Command::Usb(usb) => {
-            let mut device = ADBUSBDevice::new(usb.vendor_id, usb.product_id, usb.private_key)?;
+            let mut device =
+                ADBUSBDevice::new(usb.vendor_id, usb.product_id, usb.path_to_private_key)?;
             device.send_connect()?;
         }
     }

--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -153,7 +153,12 @@ fn main() -> Result<()> {
             }
         }
         Command::Usb(usb) => {
-            let mut device = ADBUSBDevice::new(usb.vendor_id, usb.product_id)?;
+            let mut device = ADBUSBDevice::new(
+                usb.vendor_id,
+                usb.product_id,
+                usb.private_key,
+                usb.public_key,
+            )?;
             device.send_connect()?;
         }
     }

--- a/adb_client/Cargo.toml
+++ b/adb_client/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+base64 = "0.22.1"
 byteorder = { version = "1.5.0" }
 chrono = { version = "0.4.38" }
 homedir = "0.3.3"

--- a/adb_client/src/error.rs
+++ b/adb_client/src/error.rs
@@ -69,4 +69,16 @@ pub enum RustADBError {
     /// CRC32 of the received message is invalid
     #[error("Invalid CRC32. Expected {0} got {1}")]
     InvalidCRC32(u32, u32),
+    /// An error occurred with RSA private key
+    #[error(transparent)]
+    RSAError(#[from] rsa::Error),
+    /// An error occurred with RSA PKCS#1
+    #[error(transparent)]
+    RSAPKCS1Error(#[from] rsa::pkcs1::Error),
+    /// An error occurred with RSA PKCS#8
+    #[error(transparent)]
+    RSAPKCS8Error(#[from] rsa::pkcs8::Error),
+    /// An error occurred with RSA signature
+    #[error(transparent)]
+    RSASignatureError(#[from] rsa::signature::Error),
 }

--- a/adb_client/src/usb/adb_usb_device.rs
+++ b/adb_client/src/usb/adb_usb_device.rs
@@ -62,6 +62,7 @@ fn read_adb_keypair(
 }
 
 fn generate_keypair() -> (RsaPrivateKey, String) {
+    log::info!("generating ephemeral RSA keypair");
     let mut rng = rand::thread_rng();
     let bits = 2048;
     let private_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate private key");

--- a/adb_client/src/usb/adb_usb_device.rs
+++ b/adb_client/src/usb/adb_usb_device.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::ADBUsbMessage;
 use crate::usb::adb_usb_message::{AUTH_RSAPUBLICKEY, AUTH_SIGNATURE, AUTH_TOKEN};
 use crate::{usb::usb_commands::USBCommand, ADBTransport, Result, RustADBError, USBTransport};
@@ -10,16 +12,27 @@ use sha1::Sha1;
 /// Represent a device reached directly over USB
 #[derive(Debug)]
 pub struct ADBUSBDevice {
+    // String containing the PEM representation of the public key
+    public_key: String,
+    // Parsed private key object for signing messages later
+    private_key: RsaPrivateKey,
     transport: USBTransport,
 }
 
-fn read_adb_keypair() -> Option<(RsaPrivateKey, String)> {
-    let Ok(Some(home)) = homedir::my_home() else {
-        return None;
+fn read_adb_keypair(
+    private_key: Option<PathBuf>,
+    public_key: Option<PathBuf>,
+) -> Option<(RsaPrivateKey, String)> {
+    let (private_key, public_key) = match (private_key, public_key) {
+        (Some(private_key), Some(public_key)) => (private_key, public_key),
+        _ => {
+            let Ok(Some(home)) = homedir::my_home() else {
+                return None;
+            };
+            let android_dir = home.join(".android");
+            (android_dir.join("adbkey"), android_dir.join("adbkey.pub"))
+        }
     };
-    let android_dir = home.join(".android");
-    let private_key = android_dir.join("adbkey");
-    let public_key = android_dir.join("adbkey.pub");
     let private_key = match std::fs::read_to_string(&private_key) {
         Ok(key) => RsaPrivateKey::from_pkcs8_pem(&key).expect("cannot load private key"),
         Err(e) => {
@@ -60,9 +73,20 @@ fn generate_keypair() -> (RsaPrivateKey, String) {
 
 impl ADBUSBDevice {
     /// Instantiate a new [ADBUSBDevice]
-    pub fn new(vendor_id: u16, product_id: u16) -> Result<Self> {
+    pub fn new(
+        vendor_id: u16,
+        product_id: u16,
+        private_key: Option<PathBuf>,
+        public_key: Option<PathBuf>,
+    ) -> Result<Self> {
         let transport = USBTransport::new(vendor_id, product_id);
-        Ok(Self { transport })
+        let (private_key, public_key) =
+            read_adb_keypair(private_key, public_key).unwrap_or_else(generate_keypair);
+        Ok(Self {
+            public_key,
+            private_key,
+            transport,
+        })
     }
 
     /// Send initial connect
@@ -106,8 +130,7 @@ impl ADBUSBDevice {
             }
         };
 
-        let (rsa_private_key, pub_key) = read_adb_keypair().unwrap_or_else(generate_keypair);
-        let signing_key = SigningKey::<Sha1>::new(rsa_private_key);
+        let signing_key = SigningKey::<Sha1>::new(self.private_key.clone());
         let signed_payload = signing_key.try_sign(&auth_message.payload).unwrap();
 
         let b = signed_payload.to_vec();
@@ -124,7 +147,14 @@ impl ADBUSBDevice {
             return Ok(());
         }
 
-        let message = ADBUsbMessage::new(USBCommand::Auth, AUTH_RSAPUBLICKEY, 0, pub_key.into());
+        let message = ADBUsbMessage::new(
+            USBCommand::Auth,
+            AUTH_RSAPUBLICKEY,
+            0,
+            // TODO: Maybe convert the string to a Vec<u8> and make the `new`
+            // function accept a slice of u8
+            self.public_key.clone().into(),
+        );
 
         self.transport.write_message(message)?;
 

--- a/adb_client/src/usb/adb_usb_device.rs
+++ b/adb_client/src/usb/adb_usb_device.rs
@@ -1,8 +1,11 @@
+use std::fs::read_to_string;
 use std::path::PathBuf;
 
 use super::ADBUsbMessage;
 use crate::usb::adb_usb_message::{AUTH_RSAPUBLICKEY, AUTH_SIGNATURE, AUTH_TOKEN};
 use crate::{usb::usb_commands::USBCommand, ADBTransport, Result, RustADBError, USBTransport};
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
 use rsa::pkcs1::EncodeRsaPublicKey;
 use rsa::signature::SignatureEncoding;
 use rsa::signature::Signer;
@@ -12,70 +15,49 @@ use sha1::Sha1;
 /// Represent a device reached directly over USB
 #[derive(Debug)]
 pub struct ADBUSBDevice {
-    // Raw bytes from the PEM representation of the public key
+    // Raw bytes from the public key
     public_key: Vec<u8>,
     // Signing key derived from the private key for signing messages
     signing_key: SigningKey<Sha1>,
     transport: USBTransport,
 }
 
-fn read_adb_keypair(private_key: Option<PathBuf>) -> Option<RsaPrivateKey> {
-    let private_key = private_key.or_else(|| {
+fn read_adb_private_key(private_key_path: Option<PathBuf>) -> Option<RsaPrivateKey> {
+    let private_key = private_key_path.or_else(|| {
         homedir::my_home()
             .ok()?
             .map(|home| home.join(".android").join("adbkey"))
     })?;
 
-    let private_key = match std::fs::read_to_string(&private_key) {
-        Ok(key) => RsaPrivateKey::from_pkcs8_pem(&key).expect("cannot load private key"),
-        Err(e) => {
-            log::warn!(
-                "failed to read private key file: {}: {}",
-                private_key.display(),
-                e
-            );
-            return None;
-        }
-    };
-    Some(private_key)
+    read_to_string(&private_key)
+        .map_err(RustADBError::from)
+        .and_then(|pk| Ok(RsaPrivateKey::from_pkcs8_pem(&pk)?))
+        .ok()
 }
 
-fn generate_keypair() -> RsaPrivateKey {
+fn generate_keypair() -> Result<RsaPrivateKey> {
     log::info!("generating ephemeral RSA keypair");
     let mut rng = rand::thread_rng();
-    let bits = 2048;
-
-    RsaPrivateKey::new(&mut rng, bits).expect("failed to generate private key")
+    Ok(RsaPrivateKey::new(&mut rng, 2048)?)
 }
 
 impl ADBUSBDevice {
     /// Instantiate a new [ADBUSBDevice]
-    pub fn new(vendor_id: u16, product_id: u16, private_key: Option<PathBuf>) -> Result<Self> {
-        let transport = USBTransport::new(vendor_id, product_id);
-        let private_key = read_adb_keypair(private_key).unwrap_or_else(generate_keypair);
-        let public_key_with_header = RsaPublicKey::from(&private_key)
-            .to_pkcs1_pem(rsa::pkcs8::LineEnding::LF)
-            .expect("could not encode generated public key into pkcs1_pem");
+    pub fn new(vendor_id: u16, product_id: u16, private_key_path: Option<PathBuf>) -> Result<Self> {
+        let private_key = match read_adb_private_key(private_key_path) {
+            Some(pk) => pk,
+            None => generate_keypair()?,
+        };
 
-        // Some devices seem to not like the ---BEGIN RSA PUBLIC KEY--- header
-        let mut public_key = String::with_capacity(public_key_with_header.len());
-        // ignore the header
-        let mut lines = public_key_with_header.lines().skip(1);
-        let mut prev = lines.next().unwrap();
-        // the last value in current is never used (ignore the footer)
-        while let Some(current) = lines.next() {
-            public_key.push_str(prev);
-            prev = current;
-        }
-
-        // println!("generated public key: {public_key}");
+        let der_public_key = RsaPublicKey::from(&private_key).to_pkcs1_der()?;
+        let mut public_key = BASE64_STANDARD.encode(der_public_key);
         public_key.push('\0');
-        let public_key = public_key.into_bytes();
+
         let signing_key = SigningKey::<Sha1>::new(private_key);
         Ok(Self {
-            public_key,
+            public_key: public_key.into_bytes(),
             signing_key,
-            transport,
+            transport: USBTransport::new(vendor_id, product_id),
         })
     }
 
@@ -120,15 +102,13 @@ impl ADBUSBDevice {
             }
         };
 
-        let signed_payload = self.signing_key.try_sign(&auth_message.payload).unwrap();
+        let signed_payload = self.signing_key.try_sign(&auth_message.payload)?;
         let b = signed_payload.to_vec();
 
         let message = ADBUsbMessage::new(USBCommand::Auth, AUTH_SIGNATURE, 0, b);
         self.transport.write_message(message)?;
 
         let received_response = self.transport.read_message()?;
-
-        println!("response after auth signature: {:?}", &received_response);
 
         if received_response.command == USBCommand::Cnxn {
             log::info!("Successfully authenticated on device !");

--- a/adb_client/src/usb/adb_usb_device.rs
+++ b/adb_client/src/usb/adb_usb_device.rs
@@ -12,9 +12,9 @@ use sha1::Sha1;
 /// Represent a device reached directly over USB
 #[derive(Debug)]
 pub struct ADBUSBDevice {
-    // String containing the PEM representation of the public key
+    // Raw bytes from the PEM representation of the public key
     public_key: Vec<u8>,
-    // Parsed private key object for signing messages later
+    // Signing key derived from the private key for signing messages
     signing_key: SigningKey<Sha1>,
     transport: USBTransport,
 }


### PR DESCRIPTION
### Changes
- Use the `homedir` crate to figure out the current user's home directory instead of the hardcoded path.
- Attempt to read the ADB RSA public and private keys from the `.android` directory inside the user home.
- On failure to read said keypair, we resort to generating ephemeral keypairs.
- Allow user to supply their own keypair using CLI flags.