### PR TITLE
feat: implement adb pull for usb

### DIFF
--- a/adb_client/src/adb_device_ext.rs
+++ b/adb_client/src/adb_device_ext.rs
@@ -1,6 +1,17 @@
 use std::io::Write;
 
+use serde::{Deserialize, Serialize};
+
 use crate::Result;
+
+/// Outputs of the `STAT` command on a remote file
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FileStat {
+    /// mode of the file; 0 represents unavailable
+    pub mode: u32,
+    /// size of the file if it exists
+    pub file_size: u32,
+}
 
 /// Trait representing all features available on both [`ADBServerDevice`] and [`ADBUSBDevice`]
 pub trait ADBDeviceExt {
@@ -10,4 +21,10 @@ pub trait ADBDeviceExt {
         command: impl IntoIterator<Item = S>,
         output: W,
     ) -> Result<()>;
+
+    /// Display the stat for a remote file
+    fn stat(&mut self, remote_path: &str, local_id: u32, remote_id: u32) -> Result<FileStat>;
+
+    /// Pull the remote file `source` and write its contents into [`output`]
+    fn pull<W: Write>(&mut self, source: &str, output: W) -> Result<()>;
 }

--- a/adb_client/src/lib.rs
+++ b/adb_client/src/lib.rs
@@ -14,7 +14,7 @@ mod transports;
 mod usb;
 mod utils;
 
-pub use adb_device_ext::ADBDeviceExt;
+pub use adb_device_ext::{ADBDeviceExt, FileStat};
 pub use error::{Result, RustADBError};
 pub use models::{AdbVersion, DeviceLong, DeviceShort, DeviceState, RebootType};
 pub use server::*;

--- a/adb_client/src/server/adb_server_device_commands.rs
+++ b/adb_client/src/server/adb_server_device_commands.rs
@@ -51,4 +51,17 @@ impl ADBDeviceExt for ADBServerDevice {
             }
         }
     }
+
+    fn stat(
+        &mut self,
+        remote_path: &str,
+        local_id: u32,
+        remote_id: u32,
+    ) -> Result<crate::FileStat> {
+        todo!()
+    }
+
+    fn pull<W: Write>(&mut self, source: &str, output: W) -> Result<()> {
+        todo!()
+    }
 }

--- a/adb_client/src/usb/adb_usb_device.rs
+++ b/adb_client/src/usb/adb_usb_device.rs
@@ -1,10 +1,19 @@
+use byteorder::ReadBytesExt;
 use std::fs::read_to_string;
+use std::io::Cursor;
+use std::io::Read;
+use std::io::Seek;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use byteorder::LittleEndian;
+
 use super::{ADBRsaKey, ADBUsbMessage};
 use crate::usb::adb_usb_message::{AUTH_RSAPUBLICKEY, AUTH_SIGNATURE, AUTH_TOKEN};
-use crate::{usb::usb_commands::USBCommand, ADBTransport, Result, RustADBError, USBTransport};
+use crate::{
+    usb::usb_commands::{USBCommand, USBSubcommand},
+    ADBTransport, Result, RustADBError, USBTransport,
+};
 
 /// Represent a device reached directly over USB
 #[derive(Debug)]
@@ -117,6 +126,86 @@ impl ADBUSBDevice {
             }
         }
 
+        Ok(())
+    }
+    /// Receive a message and acknowledge it by replying with an `OKAY` command
+    pub(crate) fn recv_and_reply_okay(
+        &mut self,
+        local_id: u32,
+        remote_id: u32,
+    ) -> Result<ADBUsbMessage> {
+        let message = self.transport.read_message()?;
+        self.transport.write_message(ADBUsbMessage::new(
+            USBCommand::Okay,
+            local_id,
+            remote_id,
+            "".into(),
+        ))?;
+        Ok(message)
+    }
+
+    /// Expect a message with an `OKAY` command after sending a message.
+    /// Return the value if it conforms to the constraint or error out.
+    pub(crate) fn send_and_expect_okay(&mut self, message: ADBUsbMessage) -> Result<ADBUsbMessage> {
+        self.transport.write_message(message)?;
+        let message = self.transport.read_message()?;
+        if message.command() != USBCommand::Okay {
+            return Err(RustADBError::ADBRequestFailed(format!(
+                "expected command OKAY after message, got {}",
+                message.command()
+            )));
+        }
+        Ok(message)
+    }
+
+    pub(crate) fn recv_file<W: std::io::Write>(
+        &mut self,
+        local_id: u32,
+        remote_id: u32,
+        mut output: W,
+    ) -> std::result::Result<(), RustADBError> {
+        let mut len: Option<u64> = None;
+        loop {
+            let payload = self
+                .recv_and_reply_okay(local_id, remote_id)?
+                .into_payload();
+            let mut rdr = Cursor::new(&payload);
+            while rdr.position() != payload.len() as u64 {
+                match len.take() {
+                    Some(0) | None => {
+                        rdr.seek_relative(4)?;
+                        len.replace(rdr.read_u32::<LittleEndian>()? as u64);
+                    }
+                    Some(length) => {
+                        log::debug!("len = {length}");
+                        let remaining_bytes = payload.len() as u64 - rdr.position();
+                        log::debug!(
+                            "payload length {} - reader_position {} = {remaining_bytes}",
+                            payload.len(),
+                            rdr.position()
+                        );
+                        if length < remaining_bytes {
+                            let read = std::io::copy(&mut rdr.by_ref().take(length), &mut output)?;
+                            log::debug!(
+                                "expected to read {length} bytes, actually read {read} bytes"
+                            );
+                        } else {
+                            let read = std::io::copy(&mut rdr.take(remaining_bytes), &mut output)?;
+                            len.replace(length - remaining_bytes as u64);
+                            log::debug!("expected to read {remaining_bytes} bytes, actually read {read} bytes");
+                            // this payload is exhausted
+                            break;
+                        }
+                    }
+                }
+            }
+            if Cursor::new(&payload[(payload.len() - 8)..(payload.len() - 4)])
+                .read_u32::<LittleEndian>()?
+                == USBSubcommand::Done as u32
+            {
+                break;
+            }
+        }
         Ok(())
     }
 }

--- a/adb_client/src/usb/adb_usb_device_commands.rs
+++ b/adb_client/src/usb/adb_usb_device_commands.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
 use crate::{
-    usb::{ADBUsbMessage, USBCommand},
-    ADBDeviceExt, ADBUSBDevice, Result, RustADBError,
+    usb::{ADBUsbMessage, SubcommandWithArg, USBCommand, USBSubcommand},
+    ADBDeviceExt, ADBUSBDevice, FileStat, Result, RustADBError,
 };
 
 impl ADBDeviceExt for ADBUSBDevice {
@@ -46,5 +46,61 @@ impl ADBDeviceExt for ADBUSBDevice {
         }
 
         Ok(())
+    }
+
+    // stat a file
+    fn stat(&mut self, remote_path: &str, local_id: u32, remote_id: u32) -> Result<FileStat> {
+        let stat_buffer = USBSubcommand::Stat.with_arg(remote_path.len() as u32);
+        let message = ADBUsbMessage::new(
+            USBCommand::Write,
+            local_id,
+            remote_id,
+            bincode::serialize(&stat_buffer).map_err(|_e| RustADBError::ConversionError)?,
+        );
+        self.send_and_expect_okay(message)?;
+        self.send_and_expect_okay(ADBUsbMessage::new(
+            USBCommand::Write,
+            local_id,
+            remote_id,
+            remote_path.into(),
+        ))?;
+        let response = self.recv_and_reply_okay(local_id, remote_id)?;
+        bincode::deserialize(&response.into_payload()).map_err(|_e| RustADBError::ConversionError)
+    }
+
+    fn pull<W: Write>(&mut self, source: &str, output: W) -> Result<()> {
+        let sync_directive = "sync:.\0";
+
+        let message = ADBUsbMessage::new(USBCommand::Open, 12345, 0, sync_directive.into());
+        let message = self.send_and_expect_okay(message)?;
+        let local_id = message.arg1();
+        let remote_id = message.arg0();
+
+        let FileStat { mode, file_size } = self.stat(source, local_id, remote_id)?;
+
+        log::debug!("mode: {}, file size: {}", mode, file_size);
+        if mode == 0 {
+            return Err(RustADBError::UnknownResponseType(
+                "mode is 0: source apk does not exist".to_string(),
+            ));
+        }
+
+        let recv_buffer = USBSubcommand::Recv.with_arg(source.len() as u32);
+        let recv_buffer =
+            bincode::serialize(&recv_buffer).map_err(|_e| RustADBError::ConversionError)?;
+        self.send_and_expect_okay(ADBUsbMessage::new(
+            USBCommand::Write,
+            local_id,
+            remote_id,
+            recv_buffer,
+        ))?;
+        self.send_and_expect_okay(ADBUsbMessage::new(
+            USBCommand::Write,
+            local_id,
+            remote_id,
+            source.into(),
+        ))?;
+
+        self.recv_file(local_id, remote_id, output)
     }
 }

--- a/adb_client/src/usb/adb_usb_message.rs
+++ b/adb_client/src/usb/adb_usb_message.rs
@@ -56,6 +56,10 @@ impl ADBUsbMessage {
         self.header.arg0
     }
 
+    pub fn arg1(&self) -> u32 {
+        self.header.arg1
+    }
+
     pub fn data_length(&self) -> u32 {
         self.header.data_length
     }

--- a/adb_client/src/usb/mod.rs
+++ b/adb_client/src/usb/mod.rs
@@ -7,4 +7,4 @@ mod usb_commands;
 pub use adb_rsa_key::ADBRsaKey;
 pub use adb_usb_device::ADBUSBDevice;
 pub use adb_usb_message::ADBUsbMessage;
-pub use usb_commands::USBCommand;
+pub use usb_commands::{SubcommandWithArg, USBCommand, USBSubcommand};

--- a/adb_client/src/usb/usb_commands.rs
+++ b/adb_client/src/usb/usb_commands.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::fmt::Display;
 
@@ -18,6 +19,34 @@ pub enum USBCommand {
     Okay = 0x59414b4f,
     // Sync 0x434e5953
     // Stls 0x534C5453
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize_repr, Deserialize_repr)]
+#[repr(u32)]
+pub enum USBSubcommand {
+    Stat = 0x54415453,
+    Send = 0x444E4553,
+    Recv = 0x56434552,
+    Quit = 0x54495551,
+    Fail = 0x4c494146,
+    Done = 0x454e4f44,
+    Data = 0x41544144,
+    List = 0x5453494c,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SubcommandWithArg {
+    subcommand: USBSubcommand,
+    arg: u32,
+}
+
+impl USBSubcommand {
+    pub fn with_arg(self, arg: u32) -> SubcommandWithArg {
+        SubcommandWithArg {
+            subcommand: self,
+            arg,
+        }
+    }
 }
 
 impl Display for USBCommand {


### PR DESCRIPTION
### Changes
- Added `USBSubcommand` enum for subcommands like List, Stat, etc.
- Added private `send_and_expect_okay` and `recv_and_reply_okay` method to `ADBUSBDevice` since the host and the device quite frequently acknowledge each others' messages with `OKAY` commands.
- New members in `ADBUSBDeviceExt` trait
  - A `stat` method to stat a file on the device.
  - The `pull` function which takes a source file path (string) to read from the device and writes its contents to a `Writer` output.
> [!NOTE]  
> `stat` and `pull` are implemented for the USB side but they are left as `todo!`s for `ADBServerDevice`