### PR TITLE
feat: use `AdbServerCommand` variants for usb commands when applicable

### DIFF
--- a/adb_client/src/models/adb_server_command.rs
+++ b/adb_client/src/models/adb_server_command.rs
@@ -57,6 +57,12 @@ impl Display for AdbServerCommand {
     }
 }
 
+impl AdbServerCommand {
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.to_string().into_bytes()
+    }
+}
+
 #[test]
 fn test_pair_command() {
     let host = "192.168.0.197:34783";

--- a/adb_client/src/usb/adb_usb_device.rs
+++ b/adb_client/src/usb/adb_usb_device.rs
@@ -12,6 +12,7 @@ use byteorder::LittleEndian;
 
 use super::{ADBRsaKey, ADBUsbMessage};
 use crate::constants::BUFFER_SIZE;
+use crate::models::AdbServerCommand;
 use crate::models::AdbStatResponse;
 use crate::usb::adb_usb_message::{AUTH_RSAPUBLICKEY, AUTH_SIGNATURE, AUTH_TOKEN};
 use crate::{
@@ -316,14 +317,12 @@ impl ADBUSBDevice {
     }
 
     pub(crate) fn begin_synchronization(&mut self) -> Result<(u32, u32)> {
-        let sync_directive = "sync:\0";
-
         let mut rng = rand::thread_rng();
         let message = ADBUsbMessage::new(
             USBCommand::Open,
             rng.gen(), /* Our 'local-id' */
             0,
-            sync_directive.into(),
+            AdbServerCommand::Sync.into_bytes(),
         );
         let message = self.send_and_expect_okay(message)?;
         let local_id = message.header().arg1();


### PR DESCRIPTION
### Changes
- Added a convenience method `into_bytes` for AdbServerCommand which returns a `Vec<u8>` of the stringified command
- Replaced hardcoded strings like shell, sync and reboot directives with variants of `AdbServerCommand` for the usb implementation