### PR TITLE
feat: add `adb run` command with activitymanager

### DIFF
--- a/adb_cli/src/commands/local.rs
+++ b/adb_cli/src/commands/local.rs
@@ -16,6 +16,11 @@ pub enum LocalCommand {
     Stat { path: String },
     /// Spawn an interactive shell or run a list of commands on the device
     Shell { commands: Vec<String> },
+    /// Run an activity on device specified by the intent
+    Run {
+        /// The activity intent to be invoked, it is most commonly packagename/packagename.MainActivity
+        intent: String,
+    },
     /// Reboot the device
     Reboot {
         #[clap(subcommand)]

--- a/adb_cli/src/commands/local.rs
+++ b/adb_cli/src/commands/local.rs
@@ -18,8 +18,10 @@ pub enum LocalCommand {
     Shell { commands: Vec<String> },
     /// Run an activity on device specified by the intent
     Run {
-        /// The activity intent to be invoked, it is most commonly packagename/packagename.MainActivity
-        intent: String,
+        /// The package whose activity is to be invoked
+        package: String,
+        /// The activity to be invoked itself, Usually it is MainActivity
+        activity: String,
     },
     /// Reboot the device
     Reboot {

--- a/adb_cli/src/commands/local.rs
+++ b/adb_cli/src/commands/local.rs
@@ -19,8 +19,10 @@ pub enum LocalCommand {
     /// Run an activity on device specified by the intent
     Run {
         /// The package whose activity is to be invoked
+        #[clap(short = 'p', long = "package")]
         package: String,
         /// The activity to be invoked itself, Usually it is MainActivity
+        #[clap(short = 'a', long = "activity")]
         activity: String,
     },
     /// Reboot the device

--- a/adb_cli/src/commands/usb.rs
+++ b/adb_cli/src/commands/usb.rs
@@ -37,8 +37,10 @@ pub enum UsbCommands {
     /// Run an activity on device specified by the intent
     Run {
         /// The package whose activity is to be invoked
+        #[clap(short = 'p', long = "package")]
         package: String,
         /// The activity to be invoked itself, Usually it is MainActivity
+        #[clap(short = 'a', long = "activity")]
         activity: String,
     },
     /// Reboot the device

--- a/adb_cli/src/commands/usb.rs
+++ b/adb_cli/src/commands/usb.rs
@@ -34,6 +34,11 @@ pub enum UsbCommands {
     Push { filename: String, path: String },
     /// Stat a file on device
     Stat { path: String },
+    /// Run an activity on device specified by the intent
+    Run {
+        /// The activity intent to be invoked, it is most commonly packagename/packagename.MainActivity
+        intent: String,
+    },
     /// Reboot the device
     Reboot {
         #[clap(subcommand)]

--- a/adb_cli/src/commands/usb.rs
+++ b/adb_cli/src/commands/usb.rs
@@ -36,8 +36,10 @@ pub enum UsbCommands {
     Stat { path: String },
     /// Run an activity on device specified by the intent
     Run {
-        /// The activity intent to be invoked, it is most commonly packagename/packagename.MainActivity
-        intent: String,
+        /// The package whose activity is to be invoked
+        package: String,
+        /// The activity to be invoked itself, Usually it is MainActivity
+        activity: String,
     },
     /// Reboot the device
     Reboot {

--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -65,8 +65,8 @@ fn main() -> Result<()> {
                         device.shell_command(commands, std::io::stdout())?;
                     }
                 }
-                LocalCommand::Run { intent } => {
-                    device.shell_command(["am", "start", &intent], std::io::stdout())?;
+                LocalCommand::Run { package, activity } => {
+                    device.run_activity(&package, &activity)?;
                 }
                 LocalCommand::HostFeatures => {
                     let features = device
@@ -218,8 +218,8 @@ fn main() -> Result<()> {
                     device.push(&mut input, &path)?;
                     log::info!("Uploaded {filename} to {path}");
                 }
-                UsbCommands::Run { intent } => {
-                    device.shell_command(["am", "start", &intent], std::io::stdout())?;
+                UsbCommands::Run { package, activity } => {
+                    device.run_activity(&package, &activity)?;
                 }
             }
         }

--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -65,6 +65,9 @@ fn main() -> Result<()> {
                         device.shell_command(commands, std::io::stdout())?;
                     }
                 }
+                LocalCommand::Run { intent } => {
+                    device.shell_command(["am", "start", &intent], std::io::stdout())?;
+                }
                 LocalCommand::HostFeatures => {
                     let features = device
                         .host_features()?
@@ -214,6 +217,9 @@ fn main() -> Result<()> {
                     let mut input = File::open(Path::new(&filename))?;
                     device.push(&mut input, &path)?;
                     log::info!("Uploaded {filename} to {path}");
+                }
+                UsbCommands::Run { intent } => {
+                    device.shell_command(["am", "start", &intent], std::io::stdout())?;
                 }
             }
         }

--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -66,7 +66,8 @@ fn main() -> Result<()> {
                     }
                 }
                 LocalCommand::Run { package, activity } => {
-                    device.run_activity(&package, &activity)?;
+                    let output = device.run_activity(&package, &activity)?;
+                    std::io::stdout().write_all(&output)?;
                 }
                 LocalCommand::HostFeatures => {
                     let features = device
@@ -219,7 +220,8 @@ fn main() -> Result<()> {
                     log::info!("Uploaded {filename} to {path}");
                 }
                 UsbCommands::Run { package, activity } => {
-                    device.run_activity(&package, &activity)?;
+                    let output = device.run_activity(&package, &activity)?;
+                    std::io::stdout().write_all(&output)?;
                 }
             }
         }

--- a/adb_client/src/adb_device_ext.rs
+++ b/adb_client/src/adb_device_ext.rs
@@ -29,11 +29,14 @@ pub trait ADBDeviceExt {
     /// Reboots the device using given reboot type
     fn reboot(&mut self, reboot_type: RebootType) -> Result<()>;
 
-    /// Run an `activity` from a given `package` on device
-    fn run_activity(&mut self, package: &str, activity: &str) -> Result<()> {
+    /// Run `activity` from `package` on device. Return the command output.
+    fn run_activity(&mut self, package: &str, activity: &str) -> Result<Vec<u8>> {
+        let mut output = Vec::new();
         self.shell_command(
             ["am", "start", &format!("{package}/{package}.{activity}")],
-            std::io::stdout(),
-        )
+            &mut output,
+        )?;
+
+        Ok(output)
     }
 }

--- a/adb_client/src/adb_device_ext.rs
+++ b/adb_client/src/adb_device_ext.rs
@@ -28,4 +28,12 @@ pub trait ADBDeviceExt {
 
     /// Reboots the device using given reboot type
     fn reboot(&mut self, reboot_type: RebootType) -> Result<()>;
+
+    /// Run an `activity` from a given `package` on device
+    fn run_activity(&mut self, package: &str, activity: &str) -> Result<()> {
+        self.shell_command(
+            ["am", "start", &format!("{package}/{package}.{activity}")],
+            std::io::stdout(),
+        )
+    }
 }


### PR DESCRIPTION
### Changes
- `LocalCommand` and `USBCommand` now have respective variants for "run"
- Both these impls run the shell command `am start INTENT`
- Added new trait method `run_activity` for `ADBDeviceExt`
- `run_activity` requires a package name and an associated activity to invoke
- The library ships with a default implementation of `run_activity` which invokes an intent using the `am start` command. 

Closes #16 