### PR TITLE
Fix underflow in recv

### DIFF
--- a/adb_client/src/server/device_commands/recv.rs
+++ b/adb_client/src/server/device_commands/recv.rs
@@ -32,7 +32,7 @@ impl<R: Read> Read for ADBRecvCommandReader<R> {
             match &header[..] {
                 b"DATA" => {
                     let length = self.inner.read_u32::<LittleEndian>()? as usize;
-                    let effective_read = self.inner.read(buf)?;
+                    let effective_read = self.inner.by_ref().take(length as u64).read(buf)?;
                     self.remaining_data_bytes_to_read = length - effective_read;
 
                     Ok(effective_read)

--- a/adb_client/src/server/device_commands/recv.rs
+++ b/adb_client/src/server/device_commands/recv.rs
@@ -32,7 +32,7 @@ impl<R: Read> Read for ADBRecvCommandReader<R> {
             match &header[..] {
                 b"DATA" => {
                     let length = self.inner.read_u32::<LittleEndian>()? as usize;
-                    let effective_read = self.inner.by_ref().take(length as u64).read(buf)?;
+                    let effective_read = self.inner.read(&mut buf[0..length])?;
                     self.remaining_data_bytes_to_read = length - effective_read;
 
                     Ok(effective_read)


### PR DESCRIPTION
Fairly new to rust, so might miss something obvious.

Nevertheless, I am experiencing an underflow when performing adb pull, as `effective_read` may be greater than `length`.

Fixed by using the length as a reference for the number of bytes to read. Again, not sure if this is the most optimal solution, but works for me.