### PR TITLE
feat: create an USBTransport from a rusb::Device

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup component add clippy
       - name: Run clippy
-        run : cargo clippy --all-features
+        run: cargo clippy --all-features
 
   fmt:
     name: "fmt"
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run formatter
-        run : cargo fmt --all --check
+        run: cargo fmt --all --check
 
   doc:
     name: "doc"
@@ -29,7 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run doc
-        run : cargo doc --all-features --keep-going
+        run: cargo doc --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: "-D warnings"
 
   tests:
     name: "tests"

--- a/adb_client/src/adb_device_ext.rs
+++ b/adb_client/src/adb_device_ext.rs
@@ -4,18 +4,18 @@ use std::path::Path;
 use crate::models::AdbStatResponse;
 use crate::{RebootType, Result};
 
-/// Trait representing all features available on devices.
+/// Trait representing all features available on both [`crate::ADBServerDevice`] and [`crate::ADBUSBDevice`]
 pub trait ADBDeviceExt {
-    /// Run 'command' in a shell on the device, and write its output and error streams into `output`.
+    /// Runs command in a shell on the device, and write its output and error streams into output.
     fn shell_command<S: ToString, W: Write>(
         &mut self,
         command: impl IntoIterator<Item = S>,
         output: W,
     ) -> Result<()>;
 
-    /// Start an interactive shell session on the device.
-    /// Input data is read from `reader` and write to `writer`.
-    /// `W` has a 'static bound as it is internally used in a thread.
+    /// Starts an interactive shell session on the device.
+    /// Input data is read from reader and write to writer.
+    /// W has a 'static bound as it is internally used in a thread.
     fn shell<R: Read, W: Write + Send + 'static>(&mut self, reader: R, writer: W) -> Result<()>;
 
     /// Display the stat information for a remote file

--- a/adb_client/src/server_device/commands/list.rs
+++ b/adb_client/src/server_device/commands/list.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 impl ADBServerDevice {
-    /// Lists files in `path` on the device.
+    /// Lists files in path on the device.
     pub fn list<A: AsRef<str>>(&mut self, path: A) -> Result<()> {
         let serial = self.identifier.clone();
         self.connect()?

--- a/adb_client/src/server_device/commands/recv.rs
+++ b/adb_client/src/server_device/commands/recv.rs
@@ -69,7 +69,7 @@ impl<R: Read> Read for ADBRecvCommandReader<R> {
 }
 
 impl ADBServerDevice {
-    /// Receives `path` to `stream` from the device.
+    /// Receives path to stream from the device.
     pub fn pull<A: AsRef<str>>(&mut self, path: A, stream: &mut dyn Write) -> Result<()> {
         let serial = self.identifier.clone();
         self.connect()?

--- a/adb_client/src/server_device/commands/send.rs
+++ b/adb_client/src/server_device/commands/send.rs
@@ -42,7 +42,7 @@ impl<W: Write> Write for ADBSendCommandWriter<W> {
 }
 
 impl ADBServerDevice {
-    /// Send `stream` to `path` on the device.
+    /// Send stream to path on the device.
     pub fn push<R: Read, A: AsRef<str>>(&mut self, stream: R, path: A) -> Result<()> {
         log::info!("Sending data to {}", path.as_ref());
         let serial = self.identifier.clone();

--- a/adb_client/src/server_device/commands/stat.rs
+++ b/adb_client/src/server_device/commands/stat.rs
@@ -41,7 +41,7 @@ impl ADBServerDevice {
         }
     }
 
-    /// Stat file given as `path` on the device.
+    /// Stat file given as path on the device.
     pub fn stat<A: AsRef<str>>(&mut self, path: A) -> Result<AdbStatResponse> {
         let serial = self.identifier.clone();
         self.connect()?


### PR DESCRIPTION
This allows to be more flexible on USB device we want to connect to, without making public API to complex.

Closes #65 