### PR TITLE
fix: track_devices support multiple devices

### DIFF
--- a/adb_client/src/server/commands/devices.rs
+++ b/adb_client/src/server/commands/devices.rs
@@ -97,7 +97,12 @@ impl ADBServer {
                     .get_raw_connection()?
                     .read_exact(&mut body)?;
 
-                callback(DeviceShort::try_from(body)?)?;
+                for device in body.split(|x| x.eq(&b'\n')) {
+                    if device.is_empty() {
+                        break;
+                    }
+                    callback(DeviceShort::try_from(device.to_vec())?)?;
+                }
             }
         }
     }


### PR DESCRIPTION
track_devices errors when multiple devices are plugged in.

Fixed it by stealing the code from devices() and now it works flawlessly.

Error in question: `Regex parsing error: missing field` since it received: `xxx\tdevice\nyyy\tdevice\n`