### PR TITLE
Fix for android clients that do not expect encrypted connections

### DIFF
--- a/adb_client/src/device/adb_tcp_device.rs
+++ b/adb_client/src/device/adb_tcp_device.rs
@@ -38,19 +38,26 @@ impl ADBTcpDevice {
 
         self.get_transport_mut().write_message(message)?;
 
-        // At this point, we should have received a STLS command indicating that the device wants to upgrade connection with TLS
-        self.get_transport_mut()
-            .read_message()
-            .and_then(|message| message.assert_command(MessageCommand::Stls))?;
+        let message = self.get_transport_mut().read_message()?;
 
-        self.get_transport_mut()
-            .write_message(ADBTransportMessage::new(MessageCommand::Stls, 1, 0, &[]))?;
-
-        // Upgrade TCP connection to TLS
-        self.get_transport_mut().upgrade_connection()?;
-
-        log::debug!("Connection successfully upgraded from TCP to TLS");
-
+        /// Check if client is requesting a secure connection and upgrade it if necessary
+        match message.header().command() {
+            MessageCommand::Stls => {
+                self.get_transport_mut().write_message(ADBTransportMessage::new(MessageCommand::Stls, 1, 0, &[]))?;
+                self.get_transport_mut().upgrade_connection()?;
+                log::debug!("Connection successfully upgraded from TCP to TLS");
+            }
+            MessageCommand::Cnxn => {
+                log::debug!("Unencrypted connection established");
+            }
+            _ => {
+                return Err(crate::RustADBError::WrongResponseReceived(
+                    "Expected CNXN or STLS command".to_string(),
+                    message.header().command().to_string(),
+                ));
+            }
+        }
+    
         Ok(())
     }
 

--- a/adb_client/src/device/adb_tcp_device.rs
+++ b/adb_client/src/device/adb_tcp_device.rs
@@ -40,10 +40,11 @@ impl ADBTcpDevice {
 
         let message = self.get_transport_mut().read_message()?;
 
-        /// Check if client is requesting a secure connection and upgrade it if necessary
+        // Check if client is requesting a secure connection and upgrade it if necessary
         match message.header().command() {
             MessageCommand::Stls => {
-                self.get_transport_mut().write_message(ADBTransportMessage::new(MessageCommand::Stls, 1, 0, &[]))?;
+                self.get_transport_mut()
+                    .write_message(ADBTransportMessage::new(MessageCommand::Stls, 1, 0, &[]))?;
                 self.get_transport_mut().upgrade_connection()?;
                 log::debug!("Connection successfully upgraded from TCP to TLS");
             }
@@ -57,7 +58,7 @@ impl ADBTcpDevice {
                 ));
             }
         }
-    
+
         Ok(())
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `ADBTcpDevice` implementation in the `adb_client` module. The changes solve a problem for android devices that refuse to talk over STLS and respond with CNXN previously causing the error `WrongResponseReceived("CNXN", "STLS")`

Mind taking a look at it? :)