### PR TITLE
Fix:Regex expression parsing usb incorrectly

### DIFF
--- a/adb_client/src/server/models/device_long.rs
+++ b/adb_client/src/server/models/device_long.rs
@@ -6,7 +6,7 @@ use crate::{DeviceState, RustADBError};
 use regex::bytes::Regex;
 
 static DEVICES_LONG_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new("^(?P<identifier>\\S+)\\s+(?P<state>\\w+) ((usb:(?P<usb1>.*)|(?P<usb2>\\d-\\d)) )?(product:(?P<product>\\w+) model:(?P<model>\\w+) device:(?P<device>\\w+) )?transport_id:(?P<transport_id>\\d+)$").expect("cannot build devices long regex")
+    Regex::new(r"^(?P<identifier>\S+)\s+(?P<state>\w+)\s+(usb:(?P<usb1>\S+)|(?P<usb2>\S+))?\s*(product:(?P<product>\w+)\s+model:(?P<model>\w+)\s+device:(?P<device>\w+)\s+)?transport_id:(?P<transport_id>\d+)$").expect("cannot build devices long regex")
 });
 
 /// Represents a new device with more informations.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -42,7 +42,10 @@ mod tests {
 
     #[test]
     fn test_static_devices_long() {
-        let inputs = ["7a5158f05122195aa       device 1-5 product:gts210vewifixx model:SM_T813 device:gts210vewifi transport_id:4"];
+        let inputs = ["7a5158f05122195aa       device 1-5 product:gts210vewifixx model:SM_T813 device:gts210vewifi transport_id:4",
+        "n311r05e               device usb:0-1.5 product:alioth model:M2012K11AC device:alioth transport_id:58",
+        "192.168.100.192:5555   device product:alioth model:M2012K11AC device:alioth transport_id:97",
+        "emulator-5554          device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:101"];
         for input in inputs {
             DeviceLong::try_from(input.as_bytes().to_vec())
                 .expect(&format!("cannot parse input: '{input}'"));


### PR DESCRIPTION
The original regular expression would parse 
`"n311r05e               device usb:0-1.5 product:alioth model:M2012K11AC device:alioth transport_id:58"`
into:
`DeviceLongL { identifier: "n311r05e", state: Device, usb: "0-1.5 product:alioth model:M2012K11AC device:alioth ", product: "Unk", model: "Unk", device: "Unk", transport_id: 88 }`
