### PR TITLE
refactor: remove all regexes

### DIFF
--- a/adb_client/src/emulator_device/adb_emulator_device.rs
+++ b/adb_client/src/emulator_device/adb_emulator_device.rs
@@ -30,7 +30,7 @@ impl ADBEmulatorDevice {
     pub fn new(identifier: String, ip_address: Option<Ipv4Addr>) -> Result<Self> {
         let ip_address = match ip_address {
             Some(ip_address) => ip_address,
-            None => Ipv4Addr::new(127, 0, 0, 1),
+            None => Ipv4Addr::LOCALHOST,
         };
 
         let port = identifier

--- a/adb_client/src/transports/tcp_server_transport.rs
+++ b/adb_client/src/transports/tcp_server_transport.rs
@@ -8,7 +8,7 @@ use crate::models::{AdbRequestStatus, SyncCommand};
 use crate::{ADBTransport, models::AdbServerCommand};
 use crate::{Result, RustADBError};
 
-const DEFAULT_SERVER_IP: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
+const DEFAULT_SERVER_IP: Ipv4Addr = Ipv4Addr::LOCALHOST;
 const DEFAULT_SERVER_PORT: u16 = 5037;
 
 /// Server transport running on top on TCP


### PR DESCRIPTION
Since all of the patterns are `const`, I think it might be a good idea to transpile them to Rust