### PR TITLE
Support devices that don't do auth

### DIFF
--- a/adb_client/src/device/adb_usb_device.rs
+++ b/adb_client/src/device/adb_usb_device.rs
@@ -180,6 +180,11 @@ impl ADBUSBDevice {
         self.get_transport_mut().write_message(message)?;
 
         let message = self.get_transport_mut().read_message()?;
+        // If the device returned CNXN instead of AUTH it does not require authentication,
+        // so we can skip the auth steps.
+        if message.header().command() == MessageCommand::Cnxn {
+            return Ok(());
+        }
         message.assert_command(MessageCommand::Auth)?;
 
         // At this point, we should have receive an AUTH message with arg0 == 1


### PR DESCRIPTION
Hello, I'm from the Rayhunter project. We're using this library to interface with various non-Android devices that use ADB. We've made some changes that we needed to get the library to work with said devices and to suit our needs. This is the first of several PRs to attempt to upstream these changes. Expect more to come! Any feedback is appreciated.