### PR TITLE
Fix:Regex expression parsing transport incorrectly

### DIFF
--- a/adb_client/src/server/models/device_long.rs
+++ b/adb_client/src/server/models/device_long.rs
@@ -93,7 +93,7 @@ impl TryFrom<Vec<u8>> for DeviceLong {
                         .ok_or(RustADBError::RegexParsingError)?
                         .as_bytes(),
                 )?,
-                16,
+                10,
             )?,
         })
     }


### PR DESCRIPTION
To ensure consistency with the output of the ADB client library, the transport_id should be parsed as a decimal integer rather than hexadecimal.