### PR TITLE
feat: support for `exec`

### DIFF
--- a/adb_client/src/adb_device_ext.rs
+++ b/adb_client/src/adb_device_ext.rs
@@ -15,6 +15,15 @@ pub trait ADBDeviceExt {
     /// Input data is read from reader and write to writer.
     fn shell(&mut self, reader: &mut dyn Read, writer: Box<dyn Write + Send>) -> Result<()>;
 
+    /// Runs command on the device.
+    /// Input data is read from reader and write to writer.
+    fn exec(
+        &mut self,
+        command: &str,
+        reader: &mut dyn Read,
+        writer: Box<dyn Write + Send>,
+    ) -> Result<()>;
+
     /// Display the stat information for a remote file
     fn stat(&mut self, remote_path: &dyn AsRef<str>) -> Result<AdbStatResponse>;
 

--- a/adb_client/src/message_devices/adb_message_device_commands.rs
+++ b/adb_client/src/message_devices/adb_message_device_commands.rs
@@ -22,6 +22,16 @@ impl<T: ADBMessageTransport> ADBDeviceExt for ADBMessageDevice<T> {
     }
 
     #[inline]
+    fn exec(
+        &mut self,
+        command: &str,
+        reader: &mut dyn Read,
+        writer: Box<dyn Write + Send>,
+    ) -> Result<()> {
+        self.exec(command, reader, writer)
+    }
+
+    #[inline]
     fn stat(&mut self, remote_path: &dyn AsRef<str>) -> Result<AdbStatResponse> {
         self.stat(remote_path)
     }

--- a/adb_client/src/message_devices/commands/shell.rs
+++ b/adb_client/src/message_devices/commands/shell.rs
@@ -49,10 +49,31 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
     /// Input data is read from [reader] and write to [writer].
     pub(crate) fn shell(
         &mut self,
+        reader: &mut dyn Read,
+        writer: Box<dyn Write + Send>,
+    ) -> Result<()> {
+        self.bidi_session(b"shell:\0", reader, writer)
+    }
+
+    /// Runs `command` on the device.
+    /// Input data is read from [reader] and write to [writer].
+    pub(crate) fn exec(
+        &mut self,
+        command: &str,
+        reader: &mut dyn Read,
+        writer: Box<dyn Write + Send>,
+    ) -> Result<()> {
+        self.bidi_session(format!("exec:{command}\0").as_bytes(), reader, writer)
+    }
+
+    /// Starts an bidirectional(interactive) session. This can be a shell or an exec session.
+    fn bidi_session(
+        &mut self,
+        session_data: &[u8],
         mut reader: &mut dyn Read,
         mut writer: Box<dyn Write + Send>,
     ) -> Result<()> {
-        let session = self.open_session(b"shell:\0")?;
+        let session = self.open_session(session_data)?;
 
         let mut transport = self.get_transport().clone();
 

--- a/adb_client/src/message_devices/tcp/adb_tcp_device.rs
+++ b/adb_client/src/message_devices/tcp/adb_tcp_device.rs
@@ -165,6 +165,16 @@ impl ADBDeviceExt for ADBTcpDevice {
     fn list(&mut self, path: &dyn AsRef<str>) -> Result<Vec<ADBListItemType>> {
         self.inner.list(path)
     }
+
+    #[inline]
+    fn exec(
+        &mut self,
+        command: &str,
+        reader: &mut dyn Read,
+        writer: Box<dyn Write + Send>,
+    ) -> Result<()> {
+        self.inner.exec(command, reader, writer)
+    }
 }
 
 impl Drop for ADBTcpDevice {

--- a/adb_client/src/message_devices/usb/adb_usb_device.rs
+++ b/adb_client/src/message_devices/usb/adb_usb_device.rs
@@ -299,6 +299,16 @@ impl ADBDeviceExt for ADBUSBDevice {
     fn list(&mut self, path: &dyn AsRef<str>) -> Result<Vec<ADBListItemType>> {
         self.inner.list(path)
     }
+
+    #[inline]
+    fn exec(
+        &mut self,
+        command: &str,
+        reader: &mut dyn Read,
+        writer: Box<dyn Write + Send>,
+    ) -> Result<()> {
+        self.inner.exec(command, reader, writer)
+    }
 }
 
 impl Drop for ADBUSBDevice {

--- a/adb_client/src/server/adb_server_command.rs
+++ b/adb_client/src/server/adb_server_command.rs
@@ -30,6 +30,7 @@ pub(crate) enum AdbServerCommand {
     // Local commands
     ShellCommand(String, Vec<String>),
     Shell,
+    Exec(String),
     FrameBuffer,
     Sync,
     Reboot(RebootType),
@@ -68,6 +69,7 @@ impl Display for AdbServerCommand {
                 Ok(term) => write!(f, "shell,TERM={term},raw:"),
                 Err(_) => write!(f, "shell,raw:"),
             },
+            AdbServerCommand::Exec(command) => write!(f, "exec:{command}"),
             AdbServerCommand::HostFeatures => write!(f, "host:features"),
             AdbServerCommand::Reboot(reboot_type) => {
                 write!(f, "reboot:{reboot_type}")


### PR DESCRIPTION
I've added support for the `exec` command. This implementation goes a bit further than what #132 asked for, since it also allows sending data to the invoked command.

I'm not sure if the feature check for `HostFeatures::ShellV2` or `HostFeatures::Cmd` also applies to exec. Please have a look at that before merging.