### PR TITLE
deps(adb_client): use ring rather than aws_lc_rs in rcgen

### DIFF
--- a/adb_client/Cargo.toml
+++ b/adb_client/Cargo.toml
@@ -25,10 +25,7 @@ num-bigint = { version = "0.8.4", package = "num-bigint-dig" }
 num-traits = { version = "0.2.19" }
 quick-protobuf = { version = "0.8.1" }
 rand = { version = "0.9.2" }
-rcgen = { version = "0.13.2", default-features = false, features = [
-    "aws_lc_rs",
-    "pem",
-] }
+rcgen = { version = "0.13.2" }
 regex = { version = "1.12.2", features = ["perf", "std", "unicode"] }
 rsa = { version = "0.9.8" }
 rusb = { version = "0.9.4", features = ["vendored"] }


### PR DESCRIPTION
I will change it to use `rcgen`’s default `ring`. `aws-lc-rs`, compared to `ring`, has a build-time dependency on bindgen, and when building for `armv7-linux-androideabi` it required additional build configuration. Since we are only using it through `rcgen`, I believe bindgen is unnecessary, so as long as `rcgen` supports it, `ring` should be fine.

The number of crate dependencies has not changed. (refs #112)
