### PR TITLE
feat: use ANDROID_USER_HOME environment variable if specified

### DIFF
--- a/adb_cli/src/models/adb_cli_error.rs
+++ b/adb_cli/src/models/adb_cli_error.rs
@@ -53,7 +53,6 @@ impl From<adb_client::RustADBError> for ADBCliError {
             | RustADBError::ParseIntError(_)
             | RustADBError::ConversionError
             | RustADBError::IntegerConversionError(_)
-            | RustADBError::HomeError
             | RustADBError::NoHomeDirectory
             | RustADBError::UsbError(_)
             | RustADBError::InvalidIntegrity(_, _)

--- a/adb_client/src/device/adb_usb_device.rs
+++ b/adb_client/src/device/adb_usb_device.rs
@@ -90,19 +90,18 @@ pub fn is_adb_device<T: UsbContext>(device: &Device<T>, des: &DeviceDescriptor) 
     false
 }
 
+/// Get the default path to the ADB key file.
+/// First checks for the presence of the environment variable `ANDROID_USER_HOME`, defaulting to the user's home directory.
 pub fn get_default_adb_key_path() -> Result<PathBuf> {
     let android_user_home = std::env::var("ANDROID_USER_HOME")
         .ok()
-        .map(|android_user_home| {
-            PathBuf::from(android_user_home)
-                .join("android")
-                .join("adbkey")
-        });
-    let default_dot_android = std::env::home_dir().map(|home| home.join(".android").join("adbkey"));
+        .map(|android_user_home| PathBuf::from(android_user_home).join("android"));
+    let default_dot_android = std::env::home_dir().map(|home| home.join(".android"));
 
-    android_user_home
+    Ok(android_user_home
         .or(default_dot_android)
-        .ok_or(RustADBError::NoHomeDirectory)
+        .ok_or(RustADBError::NoHomeDirectory)?
+        .join("adbkey"))
 }
 
 /// Represent a device reached and available over USB.

--- a/adb_client/src/error.rs
+++ b/adb_client/src/error.rs
@@ -63,9 +63,6 @@ pub enum RustADBError {
     /// Unimplemented framebuffer image version
     #[error("Unimplemented framebuffer image version: {0}")]
     UnimplementedFramebufferImageVersion(u32),
-    /// An error occurred while getting user's home directory
-    #[error("Cannot get user home directory")]
-    HomeError,
     /// Cannot get home directory
     #[error("Cannot get home directory")]
     NoHomeDirectory,


### PR DESCRIPTION
Refer to https://developer.android.com/tools/variables#envar

ANDROID_USER_HOME: Sets the path to the user preferences directory for tools that are part of the Android SDK. Defaults to `$HOME/.android/`
