### PR TITLE
fix: drain trailing CLSE messages in `framebuffer_inner()`

### DIFF
--- a/adb_client/src/message_devices/adb_message_device.rs
+++ b/adb_client/src/message_devices/adb_message_device.rs
@@ -123,19 +123,12 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
         session: ADBSession,
     ) -> Result<ADBTransportMessage> {
         let message = self.transport.read_message()?;
-
-        // Only acknowledge WRITE messages. CLSE and other commands should not be
-        // acknowledged with OKAY because that can confuse the remote and break
-        // subsequent session opens.
-        if message.header().command() == MessageCommand::Write {
-            self.transport.write_message(ADBTransportMessage::try_new(
-                MessageCommand::Okay,
-                session.local_id(),
-                session.remote_id(),
-                &[],
-            )?)?;
-        }
-
+        self.transport.write_message(ADBTransportMessage::try_new(
+            MessageCommand::Okay,
+            session.local_id(),
+            session.remote_id(),
+            &[],
+        )?)?;
         Ok(message)
     }
 


### PR DESCRIPTION
Fixes #162

## Solution

This PR drains any trailing CLSE messages from the transport buffer after completing a framebuffer session. This prevents leftover CLSE messages from interfering with subsequent framebuffer calls.

The same approach is already used in the shell command implementation: https://github.com/cocool97/adb_client/blob/main/adb_client/src/message_devices/commands/shell.rs#L47-L51

## Testing
The fix was tested with 100 consecutive `framebuffer_inner()` calls (as mentioned in #162) and succeeded consistently. Previously, the 2nd or 3rd call would fail with "got CLSE in response instead of OKAY".

--- 
Note: This draining logic is now used in multiple places (shell, framebuffer). In the future, it could be extracted to a utility method to reduce code duplication.