### PR TITLE
feat: add forward removal API

### DIFF
--- a/adb_client/src/models/adb_local_command.rs
+++ b/adb_client/src/models/adb_local_command.rs
@@ -11,6 +11,7 @@ pub enum ADBLocalCommand {
     Sync,
     Reboot(RebootType),
     Forward(String, String),
+    ForwardRemove(String),
     ForwardRemoveAll,
     Reverse(String, String),
     ReverseRemoveAll,
@@ -65,6 +66,7 @@ impl Display for ADBLocalCommand {
             Self::Forward(remote, local) => {
                 write!(f, "host:forward:{local};{remote}")
             }
+            Self::ForwardRemove(local) => write!(f, "host:killforward:{local}"),
             Self::ForwardRemoveAll => write!(f, "host:killforward-all"),
             Self::Reverse(remote, local) => {
                 write!(f, "reverse:forward:{remote};{local}")
@@ -81,4 +83,11 @@ impl Display for ADBLocalCommand {
             Self::Root => write!(f, "root:"),
         }
     }
+}
+
+#[test]
+fn test_forward_remove_command() {
+    let command = ADBLocalCommand::ForwardRemove("tcp:7100".to_string());
+
+    assert_eq!(command.to_string(), "host:killforward:tcp:7100");
 }

--- a/adb_client/src/server_device/commands/forward.rs
+++ b/adb_client/src/server_device/commands/forward.rs
@@ -17,6 +17,18 @@ impl ADBServerDevice {
             .map(|_| ())
     }
 
+    /// Remove a previously applied forward rule by its local endpoint.
+    pub fn forward_remove(&mut self, local: String) -> Result<()> {
+        self.set_serial_transport()?;
+
+        self.transport
+            .proxy_connection(
+                &ADBCommand::Local(ADBLocalCommand::ForwardRemove(local)),
+                false,
+            )
+            .map(|_| ())
+    }
+
     /// Remove all previously applied forward rules
     pub fn forward_remove_all(&mut self) -> Result<()> {
         self.set_serial_transport()?;


### PR DESCRIPTION
Add a server-device forward_remove method for removing a single forward
rule by its local endpoint.

Encode the request as host:killforward:{local}, matching the existing
serial-transport flow where device selection is set before sending the
local command.
