### PR TITLE
feat: add reverse removal API

### DIFF
--- a/adb_client/src/models/adb_local_command.rs
+++ b/adb_client/src/models/adb_local_command.rs
@@ -14,6 +14,7 @@ pub enum ADBLocalCommand {
     ForwardRemove(String),
     ForwardRemoveAll,
     Reverse(String, String),
+    ReverseRemove(String),
     ReverseRemoveAll,
     Reconnect,
     Remount,
@@ -71,6 +72,7 @@ impl Display for ADBLocalCommand {
             Self::Reverse(remote, local) => {
                 write!(f, "reverse:forward:{remote};{local}")
             }
+            Self::ReverseRemove(remote) => write!(f, "reverse:killforward:{remote}"),
             Self::ReverseRemoveAll => write!(f, "reverse:killforward-all"),
             Self::Reconnect => write!(f, "reconnect"),
             Self::Remount => write!(f, "remount:"),
@@ -90,4 +92,11 @@ fn test_forward_remove_command() {
     let command = ADBLocalCommand::ForwardRemove("tcp:7100".to_string());
 
     assert_eq!(command.to_string(), "host:killforward:tcp:7100");
+}
+
+#[test]
+fn test_reverse_remove_command() {
+    let command = ADBLocalCommand::ReverseRemove("tcp:7100".to_string());
+
+    assert_eq!(command.to_string(), "reverse:killforward:tcp:7100");
 }

--- a/adb_client/src/models/adb_local_command.rs
+++ b/adb_client/src/models/adb_local_command.rs
@@ -100,3 +100,10 @@ fn test_reverse_remove_command() {
 
     assert_eq!(command.to_string(), "reverse:killforward:tcp:7100");
 }
+
+#[test]
+fn test_forward_remove_command() {
+    let command = ADBLocalCommand::ForwardRemove("tcp:7100".to_string());
+
+    assert_eq!(command.to_string(), "host:killforward:tcp:7100");
+}

--- a/adb_client/src/models/adb_local_command.rs
+++ b/adb_client/src/models/adb_local_command.rs
@@ -100,10 +100,3 @@ fn test_reverse_remove_command() {
 
     assert_eq!(command.to_string(), "reverse:killforward:tcp:7100");
 }
-
-#[test]
-fn test_forward_remove_command() {
-    let command = ADBLocalCommand::ForwardRemove("tcp:7100".to_string());
-
-    assert_eq!(command.to_string(), "host:killforward:tcp:7100");
-}

--- a/adb_client/src/server_device/commands/reverse.rs
+++ b/adb_client/src/server_device/commands/reverse.rs
@@ -17,6 +17,18 @@ impl ADBServerDevice {
             .map(|_| ())
     }
 
+    /// Remove a previously applied reverse rule by its remote endpoint.
+    pub fn reverse_remove(&mut self, remote: String) -> Result<()> {
+        self.set_serial_transport()?;
+
+        self.transport
+            .proxy_connection(
+                &ADBCommand::Local(ADBLocalCommand::ReverseRemove(remote)),
+                false,
+            )
+            .map(|_| ())
+    }
+
     /// Remove all reverse rules
     pub fn reverse_remove_all(&mut self) -> Result<()> {
         self.set_serial_transport()?;


### PR DESCRIPTION
Add a server-device reverse_remove method for removing a single reverse
rule by its remote endpoint.

Encode the request as reverse:killforward:{remote}, matching the
existing serial-transport flow where device selection is set before
sending the local command.
