### PR TITLE
fix: incorrect private key used for TLS upgrade

### DIFF
--- a/adb_client/src/message_devices/tcp/adb_tcp_device.rs
+++ b/adb_client/src/message_devices/tcp/adb_tcp_device.rs
@@ -26,7 +26,13 @@ impl ADBTcpDevice {
         private_key_path: P,
     ) -> Result<Self> {
         Ok(Self {
-            inner: ADBMessageDevice::new(TcpTransport::new(address)?, private_key_path)?,
+            inner: ADBMessageDevice::new(
+                TcpTransport::new_with_custom_private_key(
+                    address,
+                    private_key_path.as_ref().to_path_buf(),
+                ),
+                private_key_path,
+            )?,
         })
     }
 }


### PR DESCRIPTION
This fixes `ADBTcpDevice::new_with_custom_private_key` so the custom private key path is passed to both the ADB authentication layer and the underlying TCP transport.

Previously, the TCP transport was created with `TcpTransport::new(address)`, which always used the default ADB key path. As a result, connections simply fail when using custom keys.