### PR TITLE
feat: add transport-id selector for ADBServerDevice

### DIFF
--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -139,9 +139,12 @@ fn inner_main() -> ADBCliResult<()> {
                 ADBServer::start(&HashMap::default(), &None);
             }
 
-            let device = match server_command.serial {
-                Some(serial) => ADBServerDevice::new(serial, Some(server_command.address)),
-                None => ADBServerDevice::autodetect(Some(server_command.address)),
+            let device = if let Some(id) = server_command.transport_id {
+                ADBServerDevice::new_with_transport_id(id, Some(server_command.address))
+            } else if let Some(serial) = server_command.serial {
+                ADBServerDevice::new(serial, Some(server_command.address))
+            } else {
+                ADBServerDevice::autodetect(Some(server_command.address))
             };
 
             match server_command.command {

--- a/adb_cli/src/models/opts.rs
+++ b/adb_cli/src/models/opts.rs
@@ -41,7 +41,8 @@ pub struct ServerCommand<T: Subcommand> {
     #[clap(short = 's', long = "serial")]
     pub serial: Option<String>,
     /// Transport id of a specific device (as shown by `adb devices -l`). Use this to
-    /// disambiguate devices that share the same serial number.
+    /// disambiguate devices that share the same serial number. Transport ids are
+    /// reassigned on device reconnect or adb-server restart and should not be cached.
     #[clap(short = 't', long = "transport-id", conflicts_with = "serial")]
     pub transport_id: Option<u32>,
     #[clap(subcommand)]

--- a/adb_cli/src/models/opts.rs
+++ b/adb_cli/src/models/opts.rs
@@ -40,6 +40,10 @@ pub struct ServerCommand<T: Subcommand> {
     /// Serial id of a specific device. Every request will be sent to this device.
     #[clap(short = 's', long = "serial")]
     pub serial: Option<String>,
+    /// Transport id of a specific device (as shown by `adb devices -l`). Use this to
+    /// disambiguate devices that share the same serial number.
+    #[clap(short = 't', long = "transport-id", conflicts_with = "serial")]
+    pub transport_id: Option<u32>,
     #[clap(subcommand)]
     pub command: T,
 }

--- a/adb_client/src/models/adb_host_command.rs
+++ b/adb_client/src/models/adb_host_command.rs
@@ -15,6 +15,7 @@ pub enum ADBHostCommand {
     Pair(SocketAddrV4, String),
     TransportAny,
     TransportSerial(String),
+    TransportId(u32),
     MDNSCheck,
     MDNSServices,
     ServerStatus,
@@ -32,6 +33,7 @@ impl Display for ADBHostCommand {
             Self::TrackDevices => write!(f, "host:track-devices"),
             Self::TransportAny => write!(f, "host:transport-any"),
             Self::TransportSerial(serial) => write!(f, "host:transport:{serial}"),
+            Self::TransportId(id) => write!(f, "host:transport-id:{id}"),
             Self::Connect(addr) => write!(f, "host:connect:{addr}"),
             Self::Disconnect(addr) => write!(f, "host:disconnect:{addr}"),
             Self::Pair(addr, code) => {

--- a/adb_client/src/server/commands/devices.rs
+++ b/adb_client/src/server/commands/devices.rs
@@ -80,6 +80,29 @@ impl ADBServer {
         }
     }
 
+    /// Get a device matching the given transport id (as returned by `adb devices -l`).
+    ///
+    /// Transport ids are unique within a running ADB server and disambiguate devices that
+    /// share the same serial number. They are reassigned on device reconnect or server
+    /// restart, so callers should re-query rather than caching the id.
+    pub fn get_device_by_transport_id(&mut self, transport_id: u32) -> Result<ADBServerDevice> {
+        let nb_devices = self
+            .devices_long()?
+            .into_iter()
+            .filter(|d| d.transport_id == transport_id)
+            .count();
+        if nb_devices == 1 {
+            Ok(ADBServerDevice::new_with_transport_id(
+                transport_id,
+                self.socket_addr,
+            ))
+        } else {
+            Err(RustADBError::DeviceNotFound(format!(
+                "could not find device with transport id {transport_id}"
+            )))
+        }
+    }
+
     /// Tracks new devices showing up.
     pub fn track_devices(&mut self, callback: impl Fn(DeviceShort) -> Result<()>) -> Result<()> {
         self.connect()?

--- a/adb_client/src/server_device/adb_server_device.rs
+++ b/adb_client/src/server_device/adb_server_device.rs
@@ -10,6 +10,15 @@ use std::net::SocketAddrV4;
 pub struct ADBServerDevice {
     /// Unique device identifier.
     pub identifier: Option<String>,
+    /// Optional transport id assigned by the ADB server.
+    ///
+    /// When set, this takes precedence over `identifier` for transport selection.
+    /// Required to disambiguate devices that report the same serial number.
+    ///
+    /// Note: transport ids are volatile. They are reassigned by the ADB server on
+    /// device reconnect or server restart, so callers must re-query `devices_long`
+    /// each time rather than caching the id across operations.
+    pub transport_id: Option<u32>,
     /// Internal [`TCPServerTransport`]
     pub(crate) transport: TCPServerTransport,
 }
@@ -22,6 +31,23 @@ impl ADBServerDevice {
 
         Self {
             identifier: Some(identifier),
+            transport_id: None,
+            transport,
+        }
+    }
+
+    /// Instantiates a new [`ADBServerDevice`] selected by its transport id (as returned by `adb devices -l`).
+    ///
+    /// Use this when multiple devices share the same serial number, since transport id is
+    /// always unique within a running ADB server. The id is volatile: do not cache it across
+    /// device reconnects or server restarts — re-query via [`crate::server::ADBServer::devices_long`].
+    #[must_use]
+    pub fn new_with_transport_id(transport_id: u32, server_addr: Option<SocketAddrV4>) -> Self {
+        let transport = TCPServerTransport::new_or_default(server_addr);
+
+        Self {
+            identifier: None,
+            transport_id: Some(transport_id),
             transport,
         }
     }
@@ -33,6 +59,7 @@ impl ADBServerDevice {
 
         Self {
             identifier: None,
+            transport_id: None,
             transport,
         }
     }
@@ -44,18 +71,19 @@ impl ADBServerDevice {
         Ok(&mut self.transport)
     }
 
-    /// Set device connection to use serial transport
+    /// Set device connection to use the configured transport.
+    ///
+    /// Prefers `transport_id` when set (unique even with duplicate serials), then falls back
+    /// to `identifier` (serial), and finally to `transport-any` when neither is configured.
     pub(crate) fn set_serial_transport(&mut self) -> Result<()> {
-        let identifier = self.identifier.clone();
-        let transport = self.connect()?;
-        if let Some(serial) = identifier {
-            transport
-                .send_adb_request(&ADBCommand::Host(ADBHostCommand::TransportSerial(serial)))?;
+        let cmd = if let Some(id) = self.transport_id {
+            ADBHostCommand::TransportId(id)
+        } else if let Some(serial) = self.identifier.clone() {
+            ADBHostCommand::TransportSerial(serial)
         } else {
-            transport.send_adb_request(&ADBCommand::Host(ADBHostCommand::TransportAny))?;
-        }
-
-        Ok(())
+            ADBHostCommand::TransportAny
+        };
+        self.connect()?.send_adb_request(&ADBCommand::Host(cmd))
     }
 }
 


### PR DESCRIPTION
Closes #205

## Summary

Pick a specific device by transport id when multiple devices share the same
serial number. The ADB protocol's host:transport:<serial> is ambiguous in
that case and adb-server rejects it with "more than one device with serial",
while host:transport-id:<id> resolves uniquely within a running server.

## Changes

### Library

On the library side, add ADBHostCommand::TransportId(u32) for the wire
variant, ADBServerDevice::new_with_transport_id as a constructor exposing a
new pub transport_id field, and ADBServer::get_device_by_transport_id as a
lookup helper that validates the id against devices_long.

set_serial_transport prefers transport_id when set and falls back to serial
then transport-any so existing callers keep their behavior.

### CLI

On the CLI side, add adb_cli --transport-id / -t to ServerCommand with
conflicts_with = "serial" so users cannot mix selectors.

## Transport Selection Flow

```mermaid
flowchart TD
    A["set_serial_transport()"] --> B{"transport_id set?"}
    B -- yes --> C["host:transport-id:&lt;id&gt;"]
    B -- no --> D{"identifier set?"}
    D -- yes --> E["host:transport:&lt;serial&gt;"]
    D -- no --> F["host:transport-any"]
```

## Notes

Transport ids are reassigned on device reconnect or adb-server restart, so
callers must re-query devices_long rather than caching the id.

## Follow-up

set_serial_transport now dispatches three transport variants (TransportId,
TransportSerial, TransportAny) so the "serial" in its name no longer
reflects the behavior. Worth renaming to set_transport in a follow-up. Out
of scope here to keep the diff minimal.

## Test plan

### Locally executable

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (8 unit and 4 doc tests pass)
- [x] `adb_cli host --help` and `adb_cli local --help` both show `-t, --transport-id <TRANSPORT_ID>`
- [x] `adb_cli local -s X -t 1 shell ...` fails with `error: the argument '--serial <SERIAL>' cannot be used with '--transport-id <TRANSPORT_ID>'`

### Requires external verification

- [x] With two devices reporting the same serial (`3d68c753fada6d30`, transport_id 6 and 7) connected to one adb-server, `adb_cli local -t 6 shell getprop ro.boot.serialno` and `-t 7` both succeed while `adb_cli local shell ...` errors with `more than one device/emulator`
- [x] `ADBServer::get_device_by_transport_id` returns the matching device for a known id and errors with `could not find device with transport id N` for an unknown id (verified via a one-shot example linked against `adb_client`)
- [x] PyADB binding (`PyADBServerDevice`) continues to work with the existing serial-only construction path (`cargo test --workspace` builds and tests `pyadb_client` cleanly with no Python-visible API change)

## Checklist

- [x] No breaking change for callers that do not set `transport_id` (serial and autodetect paths unchanged)
- [x] New public items have rustdoc (`ADBServerDevice::new_with_transport_id`, `transport_id` field, `ADBHostCommand::TransportId`, `ADBServer::get_device_by_transport_id`)
- [x] Volatility of transport id documented in rustdoc and CLI help text
- [x] CLI `-t` and `-s` declared mutually exclusive via `conflicts_with = "serial"`
- [x] `ADBHostCommand` variant addition does not break downstream matches (workspace builds clean and no exhaustive `match` on the enum)
