### PR TITLE
Handle stale ADB stream frames during session reuse

### DIFF
--- a/adb_client/src/message_devices/adb_message_device.rs
+++ b/adb_client/src/message_devices/adb_message_device.rs
@@ -167,27 +167,65 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
         )?;
         self.transport.write_message(message)?;
 
-        let response = self.transport.read_message()?;
+        loop {
+            let response = self.transport.read_message()?;
 
-        if response.header().command() != MessageCommand::Okay {
-            return Err(RustADBError::ADBRequestFailed(format!(
-                "Open session failed: got {} in response instead of OKAY",
-                response.header().command()
-            )));
+            match response.header().command() {
+                MessageCommand::Okay => {
+                    if response.header().arg1() != local_id {
+                        log::debug!(
+                            "Ignoring stale OKAY for local_id {} while opening local_id {local_id}",
+                            response.header().arg1()
+                        );
+                        continue;
+                    }
+
+                    return Ok(ADBSession::new(
+                        self.transport.clone(),
+                        local_id,
+                        response.header().arg0(),
+                    ));
+                }
+                MessageCommand::Clse => {
+                    if response.header().arg1() == local_id {
+                        return Err(RustADBError::ADBRequestFailed(format!(
+                            "Open session failed: device closed stream for local_id {local_id}"
+                        )));
+                    }
+
+                    log::debug!(
+                        "Ignoring stale CLSE for local_id {} while opening local_id {local_id}",
+                        response.header().arg1()
+                    );
+                }
+                MessageCommand::Write => {
+                    let stale_remote_id = response.header().arg0();
+                    let stale_local_id = response.header().arg1();
+
+                    if stale_local_id == local_id {
+                        return Err(RustADBError::ADBRequestFailed(format!(
+                            "Open session failed: got WRTE before OKAY for local_id {local_id}"
+                        )));
+                    }
+
+                    log::debug!(
+                        "Acknowledging and discarding stale WRTE for local_id {stale_local_id} while opening local_id {local_id}",
+                    );
+
+                    self.transport.write_message(ADBTransportMessage::try_new(
+                        MessageCommand::Okay,
+                        stale_local_id,
+                        stale_remote_id,
+                        &[],
+                    )?)?;
+                }
+                command => {
+                    return Err(RustADBError::ADBRequestFailed(format!(
+                        "Open session failed: got {command} in response instead of OKAY"
+                    )));
+                }
+            }
         }
-
-        if response.header().arg1() != local_id {
-            return Err(RustADBError::ADBRequestFailed(format!(
-                "Open session failed: responses used {} for our local_id instead of {local_id}",
-                response.header().arg1()
-            )));
-        }
-
-        Ok(ADBSession::new(
-            self.transport.clone(),
-            local_id,
-            response.header().arg0(),
-        ))
     }
 
     pub(crate) fn end_transaction(&mut self, session: &mut ADBSession<T>) -> Result<()> {
@@ -208,5 +246,277 @@ impl<T: ADBMessageTransport> Drop for ADBMessageDevice<T> {
     fn drop(&mut self) {
         // Best effort here
         let _ = self.get_transport_mut().disconnect();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use crate::{
+        RustADBError,
+        adb_transport::ADBTransport,
+        message_devices::{
+            adb_message_transport::ADBMessageTransport, adb_transport_message::ADBTransportMessage,
+            message_commands::MessageCommand,
+        },
+        models::ADBLocalCommand,
+    };
+
+    use super::ADBMessageDevice;
+
+    #[derive(Clone, Default)]
+    struct FakeTransport {
+        reads: Arc<Mutex<VecDeque<ADBTransportMessage>>>,
+        writes: Arc<Mutex<Vec<(MessageCommand, u32, u32, Vec<u8>)>>>,
+        on_open: Option<fn(u32, &mut VecDeque<ADBTransportMessage>)>,
+    }
+
+    impl FakeTransport {
+        fn with_open_response(on_open: fn(u32, &mut VecDeque<ADBTransportMessage>)) -> Self {
+            Self {
+                reads: Arc::new(Mutex::new(VecDeque::new())),
+                writes: Arc::new(Mutex::new(Vec::new())),
+                on_open: Some(on_open),
+            }
+        }
+    }
+
+    impl ADBTransport for FakeTransport {
+        fn connect(&mut self) -> crate::Result<()> {
+            Ok(())
+        }
+
+        fn disconnect(&mut self) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl ADBMessageTransport for FakeTransport {
+        fn read_message_with_timeout(
+            &mut self,
+            _read_timeout: Duration,
+        ) -> crate::Result<ADBTransportMessage> {
+            self.reads
+                .lock()
+                .expect("reads mutex poisoned")
+                .pop_front()
+                .ok_or_else(|| {
+                    RustADBError::ADBRequestFailed("unexpected end of test stream".to_string())
+                })
+        }
+
+        fn write_message_with_timeout(
+            &mut self,
+            message: ADBTransportMessage,
+            _write_timeout: Duration,
+        ) -> crate::Result<()> {
+            let header = message.header();
+            let command = header.command();
+            let arg0 = header.arg0();
+            let arg1 = header.arg1();
+            let payload = message.into_payload();
+
+            if command == MessageCommand::Open
+                && let Some(on_open) = self.on_open.take()
+            {
+                on_open(arg0, &mut self.reads.lock().expect("reads mutex poisoned"));
+            }
+
+            self.writes
+                .lock()
+                .expect("writes mutex poisoned")
+                .push((command, arg0, arg1, payload));
+            Ok(())
+        }
+    }
+
+    fn queue_open_session_stale_frames(local_id: u32, reads: &mut VecDeque<ADBTransportMessage>) {
+        let stale_local_id = 41;
+        let stale_remote_id = 1001;
+        let expected_remote_id = 2002;
+
+        reads.push_back(
+            ADBTransportMessage::try_new(
+                MessageCommand::Okay,
+                stale_remote_id,
+                stale_local_id,
+                &[],
+            )
+            .expect("stale OKAY message"),
+        );
+        reads.push_back(
+            ADBTransportMessage::try_new(
+                MessageCommand::Clse,
+                stale_remote_id,
+                stale_local_id,
+                &[],
+            )
+            .expect("stale CLSE message"),
+        );
+        reads.push_back(
+            ADBTransportMessage::try_new(MessageCommand::Okay, expected_remote_id, local_id, &[])
+                .expect("matching OKAY message"),
+        );
+    }
+
+    fn queue_open_session_stale_write_frame(
+        local_id: u32,
+        reads: &mut VecDeque<ADBTransportMessage>,
+    ) {
+        let stale_local_id = 41;
+        let stale_remote_id = 1001;
+        let expected_remote_id = 2002;
+
+        reads.push_back(
+            ADBTransportMessage::try_new(
+                MessageCommand::Write,
+                stale_remote_id,
+                stale_local_id,
+                b"stale",
+            )
+            .expect("stale WRTE message"),
+        );
+        reads.push_back(
+            ADBTransportMessage::try_new(MessageCommand::Okay, expected_remote_id, local_id, &[])
+                .expect("matching OKAY message"),
+        );
+    }
+
+    fn queue_shell_command_frames(local_id: u32, reads: &mut VecDeque<ADBTransportMessage>) {
+        let remote_id = 2002;
+
+        reads.push_back(
+            ADBTransportMessage::try_new(MessageCommand::Okay, remote_id, local_id, &[])
+                .expect("session OKAY message"),
+        );
+        reads.push_back(
+            ADBTransportMessage::try_new(MessageCommand::Write, remote_id, local_id, b"hello")
+                .expect("shell WRTE message"),
+        );
+        reads.push_back(
+            ADBTransportMessage::try_new(MessageCommand::Clse, remote_id, local_id, &[])
+                .expect("shell CLSE message"),
+        );
+    }
+
+    fn queue_shell_command_stale_write_frame(
+        local_id: u32,
+        reads: &mut VecDeque<ADBTransportMessage>,
+    ) {
+        let stale_local_id = 41;
+        let stale_remote_id = 1001;
+        let remote_id = 2002;
+
+        reads.push_back(
+            ADBTransportMessage::try_new(MessageCommand::Okay, remote_id, local_id, &[])
+                .expect("session OKAY message"),
+        );
+        reads.push_back(
+            ADBTransportMessage::try_new(
+                MessageCommand::Write,
+                stale_remote_id,
+                stale_local_id,
+                b"stale",
+            )
+            .expect("stale shell WRTE message"),
+        );
+        reads.push_back(
+            ADBTransportMessage::try_new(MessageCommand::Write, remote_id, local_id, b"hello")
+                .expect("shell WRTE message"),
+        );
+        reads.push_back(
+            ADBTransportMessage::try_new(MessageCommand::Clse, remote_id, local_id, &[])
+                .expect("shell CLSE message"),
+        );
+    }
+
+    #[test]
+    fn open_session_ignores_stale_okay_and_clse_frames() {
+        let expected_remote_id = 2002;
+        let transport = FakeTransport::with_open_response(queue_open_session_stale_frames);
+        let mut device = ADBMessageDevice { transport };
+
+        let session = device
+            .open_session(&ADBLocalCommand::Sync)
+            .expect("session should open after ignoring stale frames");
+
+        assert_eq!(session.remote_id(), expected_remote_id);
+    }
+
+    #[test]
+    fn open_session_acknowledges_and_discards_stale_write_frames() {
+        let expected_remote_id = 2002;
+        let transport = FakeTransport::with_open_response(queue_open_session_stale_write_frame);
+        let writes = transport.writes.clone();
+        let mut device = ADBMessageDevice { transport };
+
+        let session = device
+            .open_session(&ADBLocalCommand::Sync)
+            .expect("session should open after stale WRTE");
+
+        assert_eq!(session.remote_id(), expected_remote_id);
+
+        let writes = writes.lock().expect("writes mutex poisoned");
+        assert_eq!(writes.len(), 2, "expected OPEN and stale WRTE ack");
+        assert_eq!(writes[0].0, MessageCommand::Open);
+        assert_eq!(writes[1].0, MessageCommand::Okay);
+        assert_eq!(writes[1].1, 41);
+        assert_eq!(writes[1].2, 1001);
+    }
+
+    #[test]
+    fn shell_command_does_not_acknowledge_close_messages() {
+        let remote_id = 2002;
+        let transport = FakeTransport::with_open_response(queue_shell_command_frames);
+        let writes = transport.writes.clone();
+        let mut device = ADBMessageDevice { transport };
+        let mut stdout = Vec::new();
+
+        device
+            .shell_command(&"echo hello", Some(&mut stdout), None)
+            .expect("shell command should succeed");
+
+        assert_eq!(stdout, b"hello");
+
+        let writes = writes.lock().expect("writes mutex poisoned");
+        assert_eq!(writes.len(), 2, "expected OPEN and WRTE ack only");
+        assert_eq!(writes[0].0, MessageCommand::Open);
+        assert_eq!(writes[1].0, MessageCommand::Okay);
+        assert_eq!(writes[1].1, writes[0].1);
+        assert_eq!(writes[1].2, remote_id);
+    }
+
+    #[test]
+    fn shell_command_acknowledges_and_discards_stale_write_frames() {
+        let remote_id = 2002;
+        let transport = FakeTransport::with_open_response(queue_shell_command_stale_write_frame);
+        let writes = transport.writes.clone();
+        let mut device = ADBMessageDevice { transport };
+        let mut stdout = Vec::new();
+
+        device
+            .shell_command(&"echo hello", Some(&mut stdout), None)
+            .expect("shell command should succeed");
+
+        assert_eq!(stdout, b"hello");
+
+        let writes = writes.lock().expect("writes mutex poisoned");
+        assert_eq!(
+            writes.len(),
+            3,
+            "expected OPEN, stale WRTE ack, and current WRTE ack"
+        );
+        assert_eq!(writes[0].0, MessageCommand::Open);
+        assert_eq!(writes[1].0, MessageCommand::Okay);
+        assert_eq!(writes[1].1, 41);
+        assert_eq!(writes[1].2, 1001);
+        assert_eq!(writes[2].0, MessageCommand::Okay);
+        assert_eq!(writes[2].1, writes[0].1);
+        assert_eq!(writes[2].2, remote_id);
     }
 }

--- a/adb_client/src/message_devices/commands/shell.rs
+++ b/adb_client/src/message_devices/commands/shell.rs
@@ -22,15 +22,48 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
             command.as_ref().to_string(),
             Vec::new(),
         ))?;
+        let local_id = session.local_id();
+        let remote_id = session.remote_id();
 
         loop {
-            let message = session.recv_and_reply_okay()?;
-            if message.header().command() == MessageCommand::Clse {
-                break;
-            }
-            // should this just write for ::Write messages?
-            if let Some(ref mut stdout) = stdout {
-                stdout.write_all(&message.into_payload())?;
+            let message = session.get_transport_mut().read_message()?;
+            let message_remote_id = message.header().arg0();
+            let message_local_id = message.header().arg1();
+            let is_current_stream = message_remote_id == remote_id && message_local_id == local_id;
+
+            match message.header().command() {
+                MessageCommand::Write => {
+                    let response = ADBTransportMessage::try_new(
+                        MessageCommand::Okay,
+                        message_local_id,
+                        message_remote_id,
+                        &[],
+                    )?;
+                    session.get_transport_mut().write_message(response)?;
+
+                    if is_current_stream && let Some(ref mut stdout) = stdout {
+                        stdout.write_all(&message.into_payload())?;
+                    } else if !is_current_stream {
+                        log::debug!(
+                            "Acknowledging and discarding stale shell WRTE for local_id {message_local_id}"
+                        );
+                    }
+                }
+                MessageCommand::Okay => {}
+                MessageCommand::Clse => {
+                    if is_current_stream {
+                        break;
+                    }
+
+                    log::debug!(
+                        "Ignoring stale shell CLSE for local_id {message_local_id} while reading local_id {local_id}"
+                    );
+                }
+                command => {
+                    return Err(RustADBError::ADBRequestFailed(format!(
+                        "Unexpected shell response: {command}"
+                    )));
+                }
             }
         }
 
@@ -76,18 +109,39 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
         std::thread::spawn(move || -> Result<()> {
             loop {
                 let message = transport.read_message()?;
-
-                // Acknowledge for more data
-                let response =
-                    ADBTransportMessage::try_new(MessageCommand::Okay, local_id, remote_id, &[])?;
-                transport.write_message(response)?;
+                let message_remote_id = message.header().arg0();
+                let message_local_id = message.header().arg1();
+                let is_current_stream =
+                    message_remote_id == remote_id && message_local_id == local_id;
 
                 match message.header().command() {
                     MessageCommand::Write => {
-                        writer.write_all(&message.into_payload())?;
-                        writer.flush()?;
+                        let response = ADBTransportMessage::try_new(
+                            MessageCommand::Okay,
+                            message_local_id,
+                            message_remote_id,
+                            &[],
+                        )?;
+                        transport.write_message(response)?;
+                        if is_current_stream {
+                            writer.write_all(&message.into_payload())?;
+                            writer.flush()?;
+                        } else {
+                            log::debug!(
+                                "Acknowledging and discarding stale interactive shell WRTE for local_id {message_local_id}"
+                            );
+                        }
                     }
                     MessageCommand::Okay => {}
+                    MessageCommand::Clse => {
+                        if is_current_stream {
+                            return Ok(());
+                        }
+
+                        log::debug!(
+                            "Ignoring stale interactive shell CLSE for local_id {message_local_id} while reading local_id {local_id}"
+                        );
+                    }
                     _ => return Err(RustADBError::ADBShellNotSupported),
                 }
             }


### PR DESCRIPTION
## What went wrong

`adb_client` assumed the next frame read from a reused transport belonged to the command that was just sent.

That is not always true. Over TCP/wireless debugging, old stream frames can arrive late after the client has already sent a new OPEN. When that happened, the next session could consume a stale OKAY, CLSE, or WRTE as if it were the response for the new stream, causing failures like:

- `Open session failed: responses used <x> for our local_id instead of <y>`
- `Open session failed: got CLSE in response instead of OKAY`
- `Open session failed: got WRTE in response instead of OKAY`

This was also reported in #175.

Shell handling also acknowledged every received frame before checking it, so it sent `OKAY` for `CLSE`. `CLSE` is terminal and should not be acknowledged.

Reference: https://android.googlesource.com/platform/packages/modules/adb/+/1cf2f017d312f73b3dc53bda85ef2610e35a80e9/docs/dev/protocol.md

## The fix

`open_session()` now waits for the `OKAY` that matches the new stream's `local_id` instead of trusting the next frame on the socket.

While opening a session:

- stale `OKAY` and `CLSE` frames are ignored
- stale `WRTE` frames are acknowledged with their original stream ids, then discarded
- `CLSE` or early `WRTE` for the new stream still fails the open

Shell command handling now reads frames first and only sends `OKAY` for `WRTE`.

For shell sessions:

- `CLSE` is no longer acknowledged
- stale `WRTE` payload is discarded instead of being written to the current command output
- stale `CLSE` is ignored
- the session closes only on `CLSE` for the active stream

I debugged and wrote the fix with the help of GPT-5.5. I also verified the behaviour manually.