### PR TITLE
move framebuffer functionality to seperate feature

### DIFF
--- a/adb_client/Cargo.toml
+++ b/adb_client/Cargo.toml
@@ -18,15 +18,16 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["framebuffer"]
 mdns = ["dep:mdns-sd"]
 usb = ["dep:rusb"]
+framebuffer = ["dep:image"]
 
 [dependencies]
 base64 = { version = "0.22.1" }
 byteorder = { version = "1.5.0" }
 chrono = { version = "0.4.44", default-features = false, features = ["std"] }
-image = { version = "0.25.10", default-features = false, features = ["png"] }
+image = { version = "0.25.10", default-features = false, features = ["png"], optional = true }
 log = { version = "0.4.29" }
 num-bigint = { version = "0.8.6", package = "num-bigint-dig" }
 num-traits = { version = "0.2.19" }

--- a/adb_client/README.md
+++ b/adb_client/README.md
@@ -18,10 +18,11 @@ adb_client = "*"
 
 ## Crate features
 
-| Feature |                   Description                   | Default? |
-| :-----: | :---------------------------------------------: | :------: |
-| `mdns`  | Enables mDNS device discovery on local network. |    No    |
-|  `usb`  |     Enables interactions with USB devices.      |    No    |
+|    Feature    |                   Description                   | Default? |
+| :-----------: | :---------------------------------------------: | :------: |
+| `framebuffer` |      Enables _framebuffer_-related methods      |   Yes    |
+|    `mdns`     | Enables mDNS device discovery on local network. |    No    |
+|     `usb`     |     Enables interactions with USB devices.      |    No    |
 
 To deactivate some default features you can use the `default-features = false` option in your `Cargo.toml` file and manually specify the features you want to activate:
 

--- a/adb_client/src/adb_device_ext.rs
+++ b/adb_client/src/adb_device_ext.rs
@@ -1,7 +1,11 @@
-use std::io::{Cursor, Read, Write};
+use std::io::{Read, Write};
 use std::path::Path;
 
-use image::{ImageBuffer, ImageFormat, Rgba};
+#[cfg(feature = "framebuffer")]
+use {
+    image::{ImageBuffer, ImageFormat, Rgba},
+    std::io::Cursor,
+};
 
 use crate::models::{ADBListItemType, AdbStatResponse, RemountInfo};
 use crate::{ADBStatExtendedResponse, RebootType, Result};
@@ -101,12 +105,14 @@ pub trait ADBDeviceExt {
     /// Disable dm-verity on the device
     fn disable_verity(&mut self) -> Result<()>;
 
+    #[cfg(feature = "framebuffer")]
     /// Inner method requesting framebuffer from an Android device
     fn framebuffer_inner(&mut self) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>>;
 
     /// Dump framebuffer of this device into given path.
     ///
     /// Output data format is currently only `PNG`.
+    #[cfg(feature = "framebuffer")]
     fn framebuffer(&mut self, path: &dyn AsRef<Path>) -> Result<()> {
         // Big help from AOSP source code (<https://android.googlesource.com/platform/system/adb/+/refs/heads/main/framebuffer_service.cpp>)
         let img = self.framebuffer_inner()?;
@@ -116,6 +122,7 @@ pub trait ADBDeviceExt {
     /// Dump framebuffer of this device and return corresponding bytes.
     ///
     /// Output data format is currently only `PNG`.
+    #[cfg(feature = "framebuffer")]
     fn framebuffer_bytes(&mut self) -> Result<Vec<u8>> {
         let img = self.framebuffer_inner()?;
         let mut vec = Cursor::new(Vec::new());

--- a/adb_client/src/error.rs
+++ b/adb_client/src/error.rs
@@ -61,9 +61,11 @@ pub enum RustADBError {
     #[error("Cannot remount filesystem: {0}")]
     RemountError(String),
     /// An error occurred when getting device's framebuffer image
+    #[cfg(feature = "framebuffer")]
     #[error(transparent)]
     FramebufferImageError(#[from] image::error::ImageError),
     /// An error occurred when converting framebuffer content
+    #[cfg(feature = "framebuffer")]
     #[error("Cannot convert framebuffer into image")]
     FramebufferConversionError,
     /// Unimplemented framebuffer image version

--- a/adb_client/src/message_devices/adb_message_device_commands.rs
+++ b/adb_client/src/message_devices/adb_message_device_commands.rs
@@ -87,6 +87,7 @@ impl<T: ADBMessageTransport> ADBDeviceExt for ADBMessageDevice<T> {
     }
 
     #[inline]
+    #[cfg(feature = "framebuffer")]
     fn framebuffer_inner(&mut self) -> Result<image::ImageBuffer<image::Rgba<u8>, Vec<u8>>> {
         self.framebuffer_inner()
     }

--- a/adb_client/src/message_devices/commands/mod.rs
+++ b/adb_client/src/message_devices/commands/mod.rs
@@ -1,4 +1,3 @@
-mod framebuffer;
 mod install;
 mod list;
 mod pull;
@@ -11,3 +10,6 @@ mod stat;
 mod uninstall;
 mod utils;
 mod verity;
+
+#[cfg(feature = "framebuffer")]
+mod framebuffer;

--- a/adb_client/src/message_devices/tcp/adb_tcp_device.rs
+++ b/adb_client/src/message_devices/tcp/adb_tcp_device.rs
@@ -101,6 +101,7 @@ impl ADBDeviceExt for ADBTcpDevice {
     }
 
     #[inline]
+    #[cfg(feature = "framebuffer")]
     fn framebuffer_inner(&mut self) -> Result<image::ImageBuffer<image::Rgba<u8>, Vec<u8>>> {
         self.inner.framebuffer_inner()
     }

--- a/adb_client/src/message_devices/usb/adb_usb_device.rs
+++ b/adb_client/src/message_devices/usb/adb_usb_device.rs
@@ -170,6 +170,7 @@ impl ADBDeviceExt for ADBUSBDevice {
     }
 
     #[inline]
+    #[cfg(feature = "framebuffer")]
     fn framebuffer_inner(&mut self) -> Result<image::ImageBuffer<image::Rgba<u8>, Vec<u8>>> {
         self.inner.framebuffer_inner()
     }

--- a/adb_client/src/models/adb_local_command.rs
+++ b/adb_client/src/models/adb_local_command.rs
@@ -7,7 +7,6 @@ pub enum ADBLocalCommand {
     ShellCommand(String, Vec<String>),
     Shell,
     Exec(String),
-    FrameBuffer,
     Sync,
     Reboot(RebootType),
     Forward(String, String),
@@ -25,6 +24,9 @@ pub enum ADBLocalCommand {
     TcpIp(u16),
     Usb,
     Root,
+
+    #[cfg(feature = "framebuffer")]
+    FrameBuffer,
 }
 
 impl Display for ADBLocalCommand {
@@ -56,7 +58,6 @@ impl Display for ADBLocalCommand {
                 }
                 write!(f, " {package}")
             }
-            Self::FrameBuffer => write!(f, "framebuffer:"),
             Self::Install(size, user) => {
                 write!(f, "exec:cmd package 'install'")?;
                 if let Some(user) = user {
@@ -83,6 +84,9 @@ impl Display for ADBLocalCommand {
             }
             Self::Usb => write!(f, "usb:"),
             Self::Root => write!(f, "root:"),
+
+            #[cfg(feature = "framebuffer")]
+            Self::FrameBuffer => write!(f, "framebuffer:"),
         }
     }
 }

--- a/adb_client/src/models/mod.rs
+++ b/adb_client/src/models/mod.rs
@@ -4,12 +4,14 @@ mod adb_local_command;
 mod adb_request_status;
 mod adb_stat_extended_response;
 mod adb_stat_response;
-mod framebuffer_info;
 mod host_features;
 mod list_info;
 mod reboot_type;
 mod remount_info;
 mod sync_command;
+
+#[cfg(feature = "framebuffer")]
+mod framebuffer_info;
 
 pub use adb_command::ADBCommand;
 pub use adb_host_command::ADBHostCommand;
@@ -17,9 +19,11 @@ pub use adb_local_command::ADBLocalCommand;
 pub use adb_request_status::AdbRequestStatus;
 pub use adb_stat_extended_response::{ADBStatExtendedResponse, ADBStatMapping};
 pub use adb_stat_response::AdbStatResponse;
-pub use framebuffer_info::{FrameBufferInfoV1, FrameBufferInfoV2};
 pub use host_features::HostFeatures;
 pub use list_info::{ADBListItem, ADBListItemType};
 pub use reboot_type::RebootType;
 pub use remount_info::RemountInfo;
 pub use sync_command::SyncCommand;
+
+#[cfg(feature = "framebuffer")]
+pub use framebuffer_info::{FrameBufferInfoV1, FrameBufferInfoV2};

--- a/adb_client/src/server_device/adb_server_device_commands.rs
+++ b/adb_client/src/server_device/adb_server_device_commands.rs
@@ -104,6 +104,7 @@ impl ADBDeviceExt for ADBServerDevice {
         self.uninstall(package.as_ref(), user)
     }
 
+    #[cfg(feature = "framebuffer")]
     fn framebuffer_inner(&mut self) -> Result<image::ImageBuffer<image::Rgba<u8>, Vec<u8>>> {
         self.framebuffer_inner()
     }

--- a/adb_client/src/server_device/commands/mod.rs
+++ b/adb_client/src/server_device/commands/mod.rs
@@ -1,5 +1,4 @@
 mod forward;
-mod framebuffer;
 mod host_features;
 mod install;
 mod list;
@@ -17,3 +16,6 @@ mod transport;
 mod uninstall;
 mod usb;
 mod verity;
+
+#[cfg(feature = "framebuffer")]
+mod framebuffer;


### PR DESCRIPTION
This will allow the framebuffer functionality to be explicitly enabled or disabled with a feature - allowing for the image crate to be dropped for projects that do not use it. If you would like me to update the readme, docs and etc as well - please let me know what you would like to be changed/updated. Thank you for your consideration - I am happy to acclimate to whatever comes my way. 