### PR TITLE
Terminate interactive shell/exec sessions cleanly on EOF from device

### DIFF
--- a/adb_cli/src/main.rs
+++ b/adb_cli/src/main.rs
@@ -40,12 +40,12 @@ fn run_command(mut device: Box<dyn ADBDeviceExt>, command: DeviceCommands) -> AD
                 {
                     let adb_termios = ADBTermios::new(&std::io::stdin())?;
                     adb_termios.set_adb_termios()?;
-                    device.shell(&mut std::io::stdin(), Box::new(std::io::stdout()))?;
+                    device.shell(Box::new(std::io::stdin()), Box::new(std::io::stdout()))?;
                 }
 
                 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
                 {
-                    device.shell(&mut std::io::stdin(), Box::new(std::io::stdout()))?;
+                    device.shell(Box::new(std::io::stdin()), Box::new(std::io::stdout()))?;
                 }
             } else {
                 device.shell_command(&commands.join(" "), Some(&mut std::io::stdout()), None)?;

--- a/adb_client/src/adb_device_ext.rs
+++ b/adb_client/src/adb_device_ext.rs
@@ -22,14 +22,14 @@ pub trait ADBDeviceExt {
 
     /// Starts an interactive shell session on the device.
     /// Input data is read from reader and write to writer.
-    fn shell(&mut self, reader: &mut dyn Read, writer: Box<dyn Write + Send>) -> Result<()>;
+    fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()>;
 
     /// Runs command on the device.
     /// Input data is read from reader and write to writer.
     fn exec(
         &mut self,
         command: &str,
-        reader: &mut dyn Read,
+        reader: Box<dyn Read + Send>,
         writer: Box<dyn Write + Send>,
     ) -> Result<()>;
 

--- a/adb_client/src/message_devices/adb_message_device_commands.rs
+++ b/adb_client/src/message_devices/adb_message_device_commands.rs
@@ -22,7 +22,7 @@ impl<T: ADBMessageTransport> ADBDeviceExt for ADBMessageDevice<T> {
     }
 
     #[inline]
-    fn shell(&mut self, reader: &mut dyn Read, writer: Box<dyn Write + Send>) -> Result<()> {
+    fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()> {
         self.shell(reader, writer)
     }
 
@@ -30,7 +30,7 @@ impl<T: ADBMessageTransport> ADBDeviceExt for ADBMessageDevice<T> {
     fn exec(
         &mut self,
         command: &str,
-        reader: &mut dyn Read,
+        reader: Box<dyn Read + Send>,
         writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         self.exec(command, reader, writer)

--- a/adb_client/src/message_devices/commands/shell.rs
+++ b/adb_client/src/message_devices/commands/shell.rs
@@ -41,7 +41,7 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
     /// Input data is read from [reader] and write to [writer].
     pub(crate) fn shell(
         &mut self,
-        reader: &mut dyn Read,
+        reader: Box<dyn Read + Send>,
         writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         self.bidirectional_session(&ADBLocalCommand::Shell, reader, writer)
@@ -52,7 +52,7 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
     pub(crate) fn exec(
         &mut self,
         command: &str,
-        reader: &mut dyn Read,
+        reader: Box<dyn Read + Send>,
         writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         self.bidirectional_session(&ADBLocalCommand::Exec(command.to_string()), reader, writer)
@@ -62,48 +62,69 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
     fn bidirectional_session(
         &mut self,
         local_command: &ADBLocalCommand,
-        mut reader: &mut dyn Read,
+        mut reader: Box<dyn Read + Send>,
         mut writer: Box<dyn Write + Send>,
     ) -> Result<()> {
-        let session = self.open_session(local_command)?;
+        let mut session = self.open_session(local_command)?;
 
         let local_id = session.local_id();
         let remote_id = session.remote_id();
 
-        let mut transport = self.get_transport_mut().clone();
-
-        // Reading thread, reads response from adbd
-        std::thread::spawn(move || -> Result<()> {
-            loop {
-                let message = transport.read_message()?;
-
-                // Acknowledge for more data
-                let response =
-                    ADBTransportMessage::try_new(MessageCommand::Okay, local_id, remote_id, &[])?;
-                transport.write_message(response)?;
-
-                match message.header().command() {
-                    MessageCommand::Write => {
-                        writer.write_all(&message.into_payload())?;
-                        writer.flush()?;
+        // Writing thread, reads from given reader (that could be stdin e.g), and writes content to device adbd.
+        // Deliberately detached: it may stay blocked reading (e.g on stdin) after the session is over,
+        // and will die with the process once this (calling) thread has returned.
+        let mut write_transport = self.get_transport_mut().clone();
+        std::thread::spawn(move || {
+            let mut shell_writer =
+                ShellMessageWriter::new(write_transport.clone(), local_id, remote_id);
+            match std::io::copy(&mut reader, &mut shell_writer) {
+                Ok(_) => {
+                    // Reader is exhausted (e.g EOF on piped stdin), close our side of the session.
+                    // Device will answer with a `CLSE` message, terminating the reading loop below.
+                    if let Ok(message) =
+                        ADBTransportMessage::try_new(MessageCommand::Clse, local_id, remote_id, &[])
+                    {
+                        let _ = write_transport.write_message(message);
                     }
-                    MessageCommand::Okay => {}
-                    _ => return Err(RustADBError::ADBShellNotSupported),
                 }
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => (),
+                Err(e) => log::error!("Error while writing to device shell: {e}"),
             }
         });
 
-        let transport = self.get_transport_mut().clone();
-        let mut shell_writer = ShellMessageWriter::new(transport, local_id, remote_id);
+        // Reading loop, reads response from adbd in the calling thread, so that returning from
+        // this function happens as soon as the device closes the session (EOF).
+        loop {
+            let message = session.get_transport_mut().read_message()?;
 
-        // Read from given reader (that could be stdin e.g), and write content to device adbd
-        if let Err(e) = std::io::copy(&mut reader, &mut shell_writer) {
-            match e.kind() {
-                ErrorKind::BrokenPipe => return Ok(()),
-                _ => return Err(RustADBError::IOError(e)),
+            match message.header().command() {
+                MessageCommand::Write => {
+                    // Acknowledge for more data
+                    let response = ADBTransportMessage::try_new(
+                        MessageCommand::Okay,
+                        local_id,
+                        remote_id,
+                        &[],
+                    )?;
+                    session.get_transport_mut().write_message(response)?;
+
+                    writer.write_all(&message.into_payload())?;
+                    writer.flush()?;
+                }
+                MessageCommand::Okay => {}
+                MessageCommand::Clse => {
+                    // Device closed the session (EOF), acknowledge and terminate gracefully
+                    let response = ADBTransportMessage::try_new(
+                        MessageCommand::Clse,
+                        local_id,
+                        remote_id,
+                        &[],
+                    )?;
+                    let _ = session.get_transport_mut().write_message(response);
+                    return Ok(());
+                }
+                _ => return Err(RustADBError::ADBShellNotSupported),
             }
         }
-
-        Ok(())
     }
 }

--- a/adb_client/src/message_devices/tcp/README.md
+++ b/adb_client/src/message_devices/tcp/README.md
@@ -7,5 +7,5 @@ use std::net::{SocketAddr, IpAddr, Ipv4Addr};
 use adb_client::{tcp::ADBTcpDevice, ADBDeviceExt};
 
 let mut device = ADBTcpDevice::new((IpAddr::from([192, 168, 0, 10]), 43210)).expect("cannot find device");
-device.shell(&mut std::io::stdin(), Box::new(std::io::stdout()));
+device.shell(Box::new(std::io::stdin()), Box::new(std::io::stdout()));
 ```

--- a/adb_client/src/message_devices/tcp/adb_tcp_device.rs
+++ b/adb_client/src/message_devices/tcp/adb_tcp_device.rs
@@ -46,7 +46,7 @@ impl ADBDeviceExt for ADBTcpDevice {
     }
 
     #[inline]
-    fn shell(&mut self, reader: &mut dyn Read, writer: Box<dyn Write + Send>) -> Result<()> {
+    fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()> {
         self.inner.shell(reader, writer)
     }
 
@@ -115,7 +115,7 @@ impl ADBDeviceExt for ADBTcpDevice {
     fn exec(
         &mut self,
         command: &str,
-        reader: &mut dyn Read,
+        reader: Box<dyn Read + Send>,
         writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         self.inner.exec(command, reader, writer)

--- a/adb_client/src/message_devices/usb/adb_usb_device.rs
+++ b/adb_client/src/message_devices/usb/adb_usb_device.rs
@@ -115,7 +115,11 @@ impl ADBDeviceExt for ADBUSBDevice {
     }
 
     #[inline]
-    fn shell<'a>(&mut self, reader: &mut dyn Read, writer: Box<dyn Write + Send>) -> Result<()> {
+    fn shell<'a>(
+        &mut self,
+        reader: Box<dyn Read + Send>,
+        writer: Box<dyn Write + Send>,
+    ) -> Result<()> {
         self.inner.shell(reader, writer)
     }
 
@@ -184,7 +188,7 @@ impl ADBDeviceExt for ADBUSBDevice {
     fn exec(
         &mut self,
         command: &str,
-        reader: &mut dyn Read,
+        reader: Box<dyn Read + Send>,
         writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         self.inner.exec(command, reader, writer)

--- a/adb_client/src/server_device/adb_server_device_commands.rs
+++ b/adb_client/src/server_device/adb_server_device_commands.rs
@@ -66,7 +66,7 @@ impl ADBDeviceExt for ADBServerDevice {
     fn exec(
         &mut self,
         command: &str,
-        reader: &mut dyn Read,
+        reader: Box<dyn Read + Send>,
         writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         self.bidirectional_session(
@@ -76,7 +76,7 @@ impl ADBDeviceExt for ADBServerDevice {
         )
     }
 
-    fn shell(&mut self, reader: &mut dyn Read, writer: Box<dyn Write + Send>) -> Result<()> {
+    fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()> {
         self.bidirectional_session(&ADBCommand::Local(ADBLocalCommand::Shell), reader, writer)
     }
 
@@ -268,7 +268,7 @@ impl ADBServerDevice {
     fn bidirectional_session(
         &mut self,
         server_cmd: &ADBCommand,
-        mut reader: &mut dyn Read,
+        mut reader: Box<dyn Read + Send>,
         mut writer: Box<dyn Write + Send>,
     ) -> Result<()> {
         // For bidirectional session, we still need shell features
@@ -280,35 +280,38 @@ impl ADBServerDevice {
 
         let mut write_stream = read_stream.try_clone()?;
 
-        // Reading thread, reads response from adb-server
-        std::thread::spawn(move || -> Result<()> {
-            let mut buffer = vec![0; BUFFER_SIZE].into_boxed_slice();
-
-            loop {
-                match read_stream.read(&mut buffer) {
-                    Ok(0) => {
-                        read_stream.shutdown(std::net::Shutdown::Both)?;
-                        return Ok(());
-                    }
-                    Ok(size) => {
-                        writer.write_all(&buffer[..size])?;
-                        writer.flush()?;
-                    }
-                    Err(e) => {
-                        return Err(RustADBError::IOError(e));
-                    }
+        // Writing thread, reads from given reader (that could be stdin e.g), and writes content to server socket.
+        // Deliberately detached: it may stay blocked reading (e.g on stdin) after the session is over,
+        // and will die with the process once this (calling) thread has returned.
+        std::thread::spawn(move || {
+            match std::io::copy(&mut reader, &mut write_stream) {
+                Ok(_) => {
+                    // Reader is exhausted (e.g EOF on piped stdin), close our side of the connection
+                    let _ = write_stream.shutdown(std::net::Shutdown::Write);
                 }
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => (),
+                Err(e) => log::error!("Error while writing to ADB server socket: {e}"),
             }
         });
 
-        // Read from given reader (that could be stdin e.g), and write content to server socket
-        if let Err(e) = std::io::copy(&mut reader, &mut write_stream) {
-            match e.kind() {
-                ErrorKind::BrokenPipe => return Ok(()),
-                _ => return Err(RustADBError::IOError(e)),
+        // Reading loop, reads response from adb-server in the calling thread, so that returning
+        // from this function happens as soon as the connection is closed (EOF).
+        let mut buffer = vec![0; BUFFER_SIZE].into_boxed_slice();
+
+        loop {
+            match read_stream.read(&mut buffer) {
+                Ok(0) => {
+                    let _ = read_stream.shutdown(std::net::Shutdown::Both);
+                    return Ok(());
+                }
+                Ok(size) => {
+                    writer.write_all(&buffer[..size])?;
+                    writer.flush()?;
+                }
+                Err(e) => {
+                    return Err(RustADBError::IOError(e));
+                }
             }
         }
-
-        Ok(())
     }
 }


### PR DESCRIPTION
## Problem

The interactive shell (`adb_cli tcp <addr> shell`, and the `shell()` / `exec()` library APIs) never terminates when the **device** ends the session. Typing `exit` inside the shell leaves the process hung on the raw-mode TTY, ignoring `CTRL+C` — the only way out is killing it from another terminal.

This was first found and fixed in the PenumbraOS fork of this library: PenumbraOS/adb_remote_auth#6. The maintainer there asked for the fix to be contributed to the original upstream, which is this PR. It should also help with the shell-management issues tracked in #168.

## Root cause

`bidirectional_session` (both the `ADBMessageDevice` one in `message_devices/commands/shell.rs` and the `ADBServerDevice` one in `server_device/adb_server_device_commands.rs`) splits work like this:

- a **detached thread** reads device responses and writes them to `writer`,
- the **calling thread** blocks on `std::io::copy(reader, …)`, i.e. on stdin.

When the device closes the session, the detached thread dies where nobody can observe it — in the message-device case it doesn't even match `CLSE`, so it exits with `ADBShellNotSupported` silently. The calling thread stays blocked on stdin forever, and since the CLI put the TTY in raw mode, `CTRL+C` is just a `0x03` byte sent to a dead session.

## Fix

Invert the two roles:

- The **stdin→device pump** runs on the detached thread. It is deliberately detached: it may stay blocked on stdin after the session is over and dies with the process. If the reader reaches EOF (e.g. piped stdin), it now closes our side explicitly (`CLSE` for message devices, `shutdown(Write)` for the server socket) so the device answers with `CLSE` / EOF.
- The **device→writer loop** runs on the calling thread. On `CLSE` it acknowledges with `CLSE` and returns `Ok(())` (message devices); on socket EOF it returns `Ok(())` (server device). Returning from the calling thread lets `ADBTermios` restore the terminal and the process exit cleanly.

`OKAY` is now only sent to acknowledge `WRTE` messages; previously every incoming message (including `CLSE`) was acked with `OKAY`.

## ⚠️ API change (breaking)

To run the input pump on a detached thread, the reader must be owned and `Send`. `ADBDeviceExt::shell` and `ADBDeviceExt::exec` change:

```rust
// before
fn shell(&mut self, reader: &mut dyn Read, writer: Box<dyn Write + Send>) -> Result<()>;
// after
fn shell(&mut self, reader: Box<dyn Read + Send>, writer: Box<dyn Write + Send>) -> Result<()>;
```

Call sites change from `device.shell(&mut std::io::stdin(), …)` to `device.shell(Box::new(std::io::stdin()), …)`. The CLI and the `tcp/README.md` example are updated accordingly. `shell_command`, `push`, and the Python bindings are unaffected.

## Verification

Tested against a Python mock adbd speaking the ADB message protocol over TCP: `CNXN` handshake (no auth) → `OKAY` for `OPEN shell,…,raw:` → one `WRTE` (prompt) → `CLSE` after 3 s, with the TCP connection kept open afterwards (like a real adbd whose session ended but whose transport lives on). The client ran `adb_cli tcp 127.0.0.1:<port> shell` under a PTY with stdin held open.

| build | behavior after device `CLSE` |
|---|---|
| `main` (unpatched) | **hangs forever** (killed after 12 s); mock only ever sees `OKAY` acks |
| this branch | exits `rc=0` ~1 s after `CLSE`; mock sees the `WRTE` `OKAY` ack, then a proper `CLSE` ack, then the client closing the connection |

The TCP path exercises the same `ADBMessageDevice` `bidirectional_session` code as USB; the USB transport itself was not re-tested end-to-end (needs a physical device), but the changed code is transport-agnostic. No physical device was on hand for either this PR or the PenumbraOS one.

`cargo build --release` and `cargo clippy --workspace --all-targets` are clean (no new warnings; the pre-existing `pyo3-stub-gen` MSRV warnings on `main` are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
