### PR TITLE
fix: NUL-terminate ADB OPEN destinations

### DIFF
--- a/adb_client/src/message_devices/adb_message_device.rs
+++ b/adb_client/src/message_devices/adb_message_device.rs
@@ -159,6 +159,10 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
     pub(crate) fn open_session(&mut self, cmd: &ADBLocalCommand) -> Result<ADBSession<T>> {
         let mut rng = rand::rng();
         let local_id: u32 = rng.random();
+
+        // adbd used to expect a null-terminated string.
+        // keep doing so to maintain compatibility with older versions.
+        // https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/sockets.cpp;l=560?q=sockets.cpp
         let mut destination = cmd.to_string().into_bytes();
         if !destination.ends_with(&[0]) {
             destination.push(0);

--- a/adb_client/src/message_devices/adb_message_device.rs
+++ b/adb_client/src/message_devices/adb_message_device.rs
@@ -159,12 +159,16 @@ impl<T: ADBMessageTransport> ADBMessageDevice<T> {
     pub(crate) fn open_session(&mut self, cmd: &ADBLocalCommand) -> Result<ADBSession<T>> {
         let mut rng = rand::rng();
         let local_id: u32 = rng.random();
+        let mut destination = cmd.to_string().into_bytes();
+        if !destination.ends_with(&[0]) {
+            destination.push(0);
+        }
 
         let message = ADBTransportMessage::try_new(
             MessageCommand::Open,
             local_id, // Our 'local-id'
             0,
-            cmd.to_string().as_bytes(),
+            &destination,
         )?;
         self.transport.write_message(message)?;
 


### PR DESCRIPTION
## Problem

On an Android 7 device, a direct USB `push` consistently failed while opening the `sync:` service:

```text
ADB request failed - Open session failed: got CLSE in response instead of OKAY
```

The same push succeeded through an ADB server connection.

adb_client sent the OPEN destination without a trailing NUL. AOSP adb NUL-terminates this payload and notes that adbd expects a null-terminated string:

https://android.googlesource.com/platform/system/core/+/dc29476d7e029e6c477c133b71ca55d52ee95744/adb/sockets.cpp#480

## Verification

- Reproduced the direct USB push failure on an Android 7 device before this patch
- Confirmed the same direct USB push succeeds on that device after this patch
- cargo test -p adb_client

## Note

The investigation and implementation were performed with OpenAI Codex.